### PR TITLE
throw exception for invalid arguments

### DIFF
--- a/src/Callout.php
+++ b/src/Callout.php
@@ -9,7 +9,7 @@ class Callout extends Text
 {
     private $subtype;
 
-    public function __construct($text = "", $subtype = "")
+    public function __construct($text, $subtype = "")
     {
         parent::__construct($text);
         $this->subtype = $subtype;

--- a/src/Embed.php
+++ b/src/Embed.php
@@ -15,6 +15,7 @@ class Embed implements CopilotTag
 
     public function __construct($uri, $subtype = EmbedSubtype::IFRAME, $caption = "")
     {
+        if (!is_string($uri)) throw new \InvalidArgumentException('Embed::__construct first argument $uri must be a string. Given:'.($uri?" $uri":'').' ('.gettype($uri).')');
         $this->uri = self::convertHttpToHttps(trim($uri));
         $this->subtype = $subtype;
         $this->caption = $caption;

--- a/src/Heading.php
+++ b/src/Heading.php
@@ -12,7 +12,7 @@ class Heading extends Text
 
     private $level;
 
-    public function __construct($text = "", $level = self::MIN_LEVEL)
+    public function __construct($text, $level = self::MIN_LEVEL)
     {
         parent::__construct($text);
 

--- a/src/ListTag.php
+++ b/src/ListTag.php
@@ -10,8 +10,9 @@ class ListTag implements CopilotTag
     private $items;
     private $ordered;
 
-    public function __construct($items = [], $ordered = false)
+    public function __construct($items, $ordered = FALSE)
     {
+        if (!is_array($items)) throw new \InvalidArgumentException('ListTag::__construct first argument $items must be an array. Given:'.($items?" $items":'').' ('.gettype($items).')');
         $this->items = $items;
         $this->ordered = $ordered;
     }

--- a/src/Section.php
+++ b/src/Section.php
@@ -7,6 +7,11 @@ namespace CopilotTags;
  */
 class Section extends Text
 {
+    public function __construct($text = "")
+    {
+        parent::__construct($text);
+    }
+
     public function write()
     {
         return self::beautify("$this->text\n-=-=-=-\n");

--- a/src/Text.php
+++ b/src/Text.php
@@ -5,8 +5,9 @@ class Text implements CopilotTag
 {
     protected $text;
 
-    public function __construct($text = "")
+    public function __construct($text)
     {
+        if (!is_string($text)) throw new \InvalidArgumentException('Text::__construct first argument $text must be a string. Given:'.($text?" $text":'').' ('.gettype($text).')');
         $this->text = $text;
     }
 

--- a/tests/BlockquoteTest.php
+++ b/tests/BlockquoteTest.php
@@ -25,4 +25,35 @@ class BlockquoteTest extends CopilotTagTest
             ]
         ];
     }
+
+    public function expectedConstructExceptions()
+    {
+        return [
+            [
+                Blockquote::class,
+                [NULL],
+                InvalidArgumentException::class
+            ],
+            [
+                Blockquote::class,
+                [FALSE],
+                InvalidArgumentException::class
+            ],
+            [
+                Blockquote::class,
+                [TRUE],
+                InvalidArgumentException::class
+            ],
+            [
+                Blockquote::class,
+                [5],
+                InvalidArgumentException::class
+            ],
+            [
+                Blockquote::class,
+                [[]],
+                InvalidArgumentException::class
+            ]
+        ];
+    }
 }

--- a/tests/CalloutTest.php
+++ b/tests/CalloutTest.php
@@ -20,12 +20,39 @@ class CalloutTest extends CopilotTagTest
                 ""
             ],
             [
-                new Callout(),
-                ""
-            ],
-            [
                 new Callout("Hello world!"),
                 "+++\nHello world!\n+++\n"
+            ]
+        ];
+    }
+
+    public function expectedConstructExceptions()
+    {
+        return [
+            [
+                Callout::class,
+                [NULL],
+                InvalidArgumentException::class
+            ],
+            [
+                Callout::class,
+                [FALSE],
+                InvalidArgumentException::class
+            ],
+            [
+                Callout::class,
+                [TRUE],
+                InvalidArgumentException::class
+            ],
+            [
+                Callout::class,
+                [5],
+                InvalidArgumentException::class
+            ],
+            [
+                Callout::class,
+                [[]],
+                InvalidArgumentException::class
             ]
         ];
     }

--- a/tests/CopilotTagTest.php
+++ b/tests/CopilotTagTest.php
@@ -12,5 +12,16 @@ abstract class CopilotTagTest extends TestCase
         $this->assertEquals($expected, $tag->write());
     }
 
+    /**
+     * @dataProvider expectedConstructExceptions
+     */
+    public function testConstructException($class = NULL, $args = [], $exceptionType = Exception::class)
+    {
+        if (!isset($class)) return;
+        $this->expectException($exceptionType);
+        new $class(...$args);
+    }
+
+    public function expectedConstructExceptions() { return [[]]; }
     abstract public function expectedWrites();
 }

--- a/tests/EmbedTest.php
+++ b/tests/EmbedTest.php
@@ -18,4 +18,35 @@ class EmbedTest extends CopilotTagTest
             ]
         ];
     }
+
+    public function expectedConstructExceptions()
+    {
+        return [
+            [
+                Embed::class,
+                [NULL],
+                InvalidArgumentException::class
+            ],
+            [
+                Embed::class,
+                [FALSE],
+                InvalidArgumentException::class
+            ],
+            [
+                Embed::class,
+                [TRUE],
+                InvalidArgumentException::class
+            ],
+            [
+                Embed::class,
+                [5],
+                InvalidArgumentException::class
+            ],
+            [
+                Embed::class,
+                [[]],
+                InvalidArgumentException::class
+            ]
+        ];
+    }
 }

--- a/tests/HeadingTest.php
+++ b/tests/HeadingTest.php
@@ -24,16 +24,43 @@ class HeadingTest extends CopilotTagTest
                 ""
             ],
             [
-                new Heading(),
-                ""
-            ],
-            [
                 new Heading("Hello world!"),
                 "## Hello world!\n"
             ],
             [
                 new Heading("Hello world!", 1),
                 "## Hello world!\n"
+            ]
+        ];
+    }
+
+    public function expectedConstructExceptions()
+    {
+        return [
+            [
+                Heading::class,
+                [NULL],
+                InvalidArgumentException::class
+            ],
+            [
+                Heading::class,
+                [FALSE],
+                InvalidArgumentException::class
+            ],
+            [
+                Heading::class,
+                [TRUE],
+                InvalidArgumentException::class
+            ],
+            [
+                Heading::class,
+                [5],
+                InvalidArgumentException::class
+            ],
+            [
+                Heading::class,
+                [[]],
+                InvalidArgumentException::class
             ]
         ];
     }

--- a/tests/InlineTextTest.php
+++ b/tests/InlineTextTest.php
@@ -13,4 +13,35 @@ class InlineTextTest extends CopilotTagTest
             ]
         ];
     }
+
+    public function expectedConstructExceptions()
+    {
+        return [
+            [
+                InlineText::class,
+                [NULL],
+                InvalidArgumentException::class
+            ],
+            [
+                InlineText::class,
+                [FALSE],
+                InvalidArgumentException::class
+            ],
+            [
+                InlineText::class,
+                [TRUE],
+                InvalidArgumentException::class
+            ],
+            [
+                InlineText::class,
+                [5],
+                InvalidArgumentException::class
+            ],
+            [
+                InlineText::class,
+                [[]],
+                InvalidArgumentException::class
+            ]
+        ];
+    }
 }

--- a/tests/LinkTest.php
+++ b/tests/LinkTest.php
@@ -13,4 +13,35 @@ class LinkTest extends CopilotTagTest
             ]
         ];
     }
+
+    public function expectedConstructExceptions()
+    {
+        return [
+            [
+                Link::class,
+                [NULL],
+                InvalidArgumentException::class
+            ],
+            [
+                Link::class,
+                [FALSE],
+                InvalidArgumentException::class
+            ],
+            [
+                Link::class,
+                [TRUE],
+                InvalidArgumentException::class
+            ],
+            [
+                Link::class,
+                [5],
+                InvalidArgumentException::class
+            ],
+            [
+                Link::class,
+                [[]],
+                InvalidArgumentException::class
+            ]
+        ];
+    }
 }

--- a/tests/ListItemTest.php
+++ b/tests/ListItemTest.php
@@ -13,4 +13,35 @@ class ListItemTest extends CopilotTagTest
             ]
         ];
     }
+
+    public function expectedConstructExceptions()
+    {
+        return [
+            [
+                ListItem::class,
+                [NULL],
+                InvalidArgumentException::class
+            ],
+            [
+                ListItem::class,
+                [FALSE],
+                InvalidArgumentException::class
+            ],
+            [
+                ListItem::class,
+                [TRUE],
+                InvalidArgumentException::class
+            ],
+            [
+                ListItem::class,
+                [5],
+                InvalidArgumentException::class
+            ],
+            [
+                ListItem::class,
+                [[]],
+                InvalidArgumentException::class
+            ]
+        ];
+    }
 }

--- a/tests/ListTagTest.php
+++ b/tests/ListTagTest.php
@@ -13,4 +13,35 @@ class ListTagTest extends CopilotTagTest
             ]
         ];
     }
+
+    public function expectedConstructExceptions()
+    {
+        return [
+            [
+                ListTag::class,
+                [NULL],
+                InvalidArgumentException::class
+            ],
+            [
+                ListTag::class,
+                [FALSE],
+                InvalidArgumentException::class
+            ],
+            [
+                ListTag::class,
+                [TRUE],
+                InvalidArgumentException::class
+            ],
+            [
+                ListTag::class,
+                [5],
+                InvalidArgumentException::class
+            ],
+            [
+                ListTag::class,
+                ["my string"],
+                InvalidArgumentException::class
+            ]
+        ];
+    }
 }

--- a/tests/ParagraphTest.php
+++ b/tests/ParagraphTest.php
@@ -18,10 +18,37 @@ class ParagraphTest extends CopilotTagTest
             [
                 new Paragraph(""),
                 ""
+            ]
+        ];
+    }
+
+    public function expectedConstructExceptions()
+    {
+        return [
+            [
+                Paragraph::class,
+                [NULL],
+                InvalidArgumentException::class
             ],
             [
-                new Paragraph(),
-                ""
+                Paragraph::class,
+                [FALSE],
+                InvalidArgumentException::class
+            ],
+            [
+                Paragraph::class,
+                [TRUE],
+                InvalidArgumentException::class
+            ],
+            [
+                Paragraph::class,
+                [5],
+                InvalidArgumentException::class
+            ],
+            [
+                Paragraph::class,
+                [[]],
+                InvalidArgumentException::class
             ]
         ];
     }

--- a/tests/TextTest.php
+++ b/tests/TextTest.php
@@ -20,10 +20,6 @@ class TextTest extends CopilotTagTest
                 ""
             ],
             [
-                new Text(),
-                ""
-            ],
-            [
                 new Text("Hello\nworld!"),
                 "Hello\nworld!"
             ],
@@ -38,6 +34,37 @@ class TextTest extends CopilotTagTest
             [
                 new Text("Hello\n\n\n       \nworld!"),
                 "Hello\n\nworld!"
+            ]
+        ];
+    }
+
+    public function expectedConstructExceptions()
+    {
+        return [
+            [
+                Text::class,
+                [NULL],
+                InvalidArgumentException::class
+            ],
+            [
+                Text::class,
+                [FALSE],
+                InvalidArgumentException::class
+            ],
+            [
+                Text::class,
+                [TRUE],
+                InvalidArgumentException::class
+            ],
+            [
+                Text::class,
+                [5],
+                InvalidArgumentException::class
+            ],
+            [
+                Text::class,
+                [[]],
+                InvalidArgumentException::class
             ]
         ];
     }


### PR DESCRIPTION
We should throw an exception if `text` or `uri` arguments are omitted (other than in Section).