### PR TITLE
add InlineText delimiters

### DIFF
--- a/src/InlineText.php
+++ b/src/InlineText.php
@@ -12,12 +12,12 @@ namespace CopilotTags;
 class InlineText extends Text
 {
 
-    private $mdTag;
+    private $delimiter;
 
-    public function __construct($text, $markdownTag = "")
+    public function __construct($text, $delimiter = "")
     {
         parent::__construct($text);
-        $this->mdTag = $markdownTag;
+        $this->delimiter = $delimiter;
     }
 
     public function write()
@@ -33,7 +33,7 @@ class InlineText extends Text
           $tag = explode("\n", $tag);
           $tag = array_map(function ($splitTag) {
             if (preg_match(Embed::EMBED_PATTERN, $splitTag)) return $splitTag;// Don't wrap embeds
-            return (new InlineText($splitTag, $this->mdTag))->write();
+            return (new InlineText($splitTag, $this->delimiter))->write();
           }, $tag);
           $tag = implode("\n", $tag);
         } else {
@@ -41,7 +41,7 @@ class InlineText extends Text
           $leftWhitespace = StringUtils::leadingSpace($tag);
           $rightWhitespace = StringUtils::trailingSpace($tag);
           $tag = trim($tag);
-          $tag = "{$leftWhitespace}{$this->mdTag}{$tag}{$this->mdTag}{$rightWhitespace}";
+          $tag = "{$leftWhitespace}{$this->delimiter}{$tag}{$this->delimiter}{$rightWhitespace}";
         }
 
         return self::beautify($tag);

--- a/src/InlineText.php
+++ b/src/InlineText.php
@@ -4,6 +4,10 @@ namespace CopilotTags;
 /**
  * Inline text
  * CommonMark spec: http://spec.commonmark.org/0.27/#inlines
+ * CFM spec (delete): https://github.com/conde-nast-international/copilot-markdown/blob/master/specification/0E.md#314-delete
+ * CFM spec (superscript): https://github.com/conde-nast-international/copilot-markdown/blob/master/specification/0E.md#319-superscript
+ * CFM spec (subscript): https://github.com/conde-nast-international/copilot-markdown/blob/master/specification/0E.md#3110-subscript
+ * CFM spec (emphasis): https://github.com/conde-nast-international/copilot-markdown/blob/master/specification/0E.md#3111-emphasis
  */
 class InlineText extends Text
 {

--- a/src/InlineTextDelimiter.php
+++ b/src/InlineTextDelimiter.php
@@ -3,6 +3,11 @@ namespace CopilotTags;
 
 /**
  * Inline text delimiters
+ * CommonMark spec (emphasis and strong emphasis): http://spec.commonmark.org/0.27/#emphasis-and-strong-emphasis
+ * CFM spec (delete): https://github.com/conde-nast-international/copilot-markdown/blob/master/specification/0E.md#314-delete
+ * CFM spec (superscript): https://github.com/conde-nast-international/copilot-markdown/blob/master/specification/0E.md#319-superscript
+ * CFM spec (subscript): https://github.com/conde-nast-international/copilot-markdown/blob/master/specification/0E.md#3110-subscript
+ * CFM spec (emphasis): https://github.com/conde-nast-international/copilot-markdown/blob/master/specification/0E.md#3111-emphasis
  */
 abstract class InlineTextDelimiter
 {

--- a/src/InlineTextDelimiter.php
+++ b/src/InlineTextDelimiter.php
@@ -1,0 +1,14 @@
+<?php
+namespace CopilotTags;
+
+/**
+ * Inline text delimiters
+ */
+abstract class InlineTextDelimiter
+{
+    const EMPHASIS = "*";
+    const STRONG = "**";
+    const SUBSCRIPT = "~";
+    const SUPERSCRIPT = "^";
+    const DELETE = "~~";
+}


### PR DESCRIPTION
Task: https://app.clubhouse.io/condenastinternational/story/7146

This adds `InlineTextDelimiter` and links to the relevant sections of the Markdown spec.