### PR TITLE
various cleanup

### DIFF
--- a/example/example.php
+++ b/example/example.php
@@ -26,12 +26,12 @@ xml_set_element_handler($parser, 'on_open_tag', 'on_close_tag');
 try {
     $xml_parse_success = xml_parse($parser, $xml_body, TRUE);
     if(count($markdown_stack) !== 1) $xml_parse_success = 0;
-    if (!$xml_parse_success) {
+    if(!$xml_parse_success) {
         $error_code = xml_get_error_code($parser);
         $error_string = xml_error_string($error_code);
         $line = xml_get_current_line_number($parser);
         $column = xml_get_current_column_number($parser);
-        if (is_string($error_string) && strlen($error_string)) $error_string = ": $error_string";
+        if(is_string($error_string) && strlen($error_string)) $error_string = ": $error_string";
         throw new Exception("Error ($error_code) parsing XML at $line:$column of \"".FILENAME."\"$error_string.");
     }
     $markdown_body = array_pop($markdown_stack);

--- a/example/example.php
+++ b/example/example.php
@@ -25,7 +25,7 @@ xml_set_default_handler($parser, 'add_text');
 xml_set_element_handler($parser, 'on_open_tag', 'on_close_tag');
 try {
     $xml_parse_success = xml_parse($parser, $xml_body, TRUE);
-    if(count($markdown_stack) !== 1) $xml_parse_success = 0;
+    if(count($markdown_stack) != 1) $xml_parse_success = 0;
     if(!$xml_parse_success) {
         $error_code = xml_get_error_code($parser);
         $error_string = xml_error_string($error_code);
@@ -86,7 +86,7 @@ function on_close_tag($parser, $name) {
 
     $line = xml_get_current_line_number($parser);
     $column = xml_get_current_column_number($parser);
-    if($tagname !== $tagname_open) throw new Exception("Error parsing XML at $line:$column of \"".FILENAME."\". Open tag \"$tagname_open\" did not have matching close tag. Found close tag \"$tagname\" instead.");
+    if($tagname != $tagname_open) throw new Exception("Error parsing XML at $line:$column of \"".FILENAME."\". Open tag \"$tagname_open\" did not have matching close tag. Found close tag \"$tagname\" instead.");
 
     $tag = NULL;
     switch($tagname) {

--- a/src/Blockquote.php
+++ b/src/Blockquote.php
@@ -9,9 +9,9 @@ class Blockquote extends Text
 {
     public function write()
     {
-        if ($this->text == "") return self::beautify($this->text);
+        if($this->text == "") return self::beautify($this->text);
 
-        $write_line = function ($str) { return "> $str\n"; };
+        $write_line = function($str) { return "> $str\n"; };
         $lines = explode("\n", $this->text);
         $lines = array_map($write_line, $lines);
         return self::beautify(implode("", $lines));

--- a/src/Blockquote.php
+++ b/src/Blockquote.php
@@ -11,10 +11,9 @@ class Blockquote extends Text
     {
         if ($this->text == "") return self::beautify($this->text);
 
-        $quote = function ($str) { return "> $str\n"; };
-        $tag = explode("\n", $this->text);
-        $tag = array_map($quote, $tag);
-        $tag = implode("", $tag);
-        return self::beautify($tag);
+        $write_line = function ($str) { return "> $str\n"; };
+        $lines = explode("\n", $this->text);
+        $lines = array_map($write_line, $lines);
+        return self::beautify(implode("", $lines));
     }
 }

--- a/src/Callout.php
+++ b/src/Callout.php
@@ -12,7 +12,7 @@ class Callout extends Text
     public function __construct($text, $subtype = "")
     {
         parent::__construct($text);
-        if (!is_string($subtype)) throw new \InvalidArgumentException("Callout::__construct second argument \$subtype must be a string. Given: ".($subtype ? "$subtype " : "")."(".gettype($subtype).").");
+        if(!is_string($subtype)) throw new \InvalidArgumentException("Callout::__construct second argument \$subtype must be a string. Given: ".($subtype ? "$subtype " : "")."(".gettype($subtype).").");
         $this->subtype = $subtype;
     }
 

--- a/src/Callout.php
+++ b/src/Callout.php
@@ -19,8 +19,8 @@ class Callout extends Text
     public function write()
     {
         $tag = $this->text;
-        if (trim($tag) !== "") $tag = "+++$this->subtype\n$tag\n+++";
-        if ($tag !== "") $tag = "$tag\n";
+        if(trim($tag) !== "") $tag = "+++$this->subtype\n$tag\n+++";
+        if($tag !== "") $tag = "$tag\n";
         return self::beautify($tag);
     }
 }

--- a/src/Callout.php
+++ b/src/Callout.php
@@ -12,7 +12,7 @@ class Callout extends Text
     public function __construct($text, $subtype = "")
     {
         parent::__construct($text);
-        if(!is_string($subtype)) throw new \InvalidArgumentException("Callout::__construct second argument \$subtype must be a string. Given: ".($subtype ? "$subtype " : "")."(".gettype($subtype).").");
+        if(!is_string($subtype)) throw new \InvalidArgumentException(__METHOD__." second argument \$subtype must be a string. Given: ".($subtype ? "$subtype " : "")."(".gettype($subtype).").");
         $this->subtype = $subtype;
     }
 

--- a/src/Embed.php
+++ b/src/Embed.php
@@ -15,14 +15,14 @@ class Embed implements CopilotTag
 
     public function __construct($uri, $subtype = EmbedSubtype::IFRAME, $caption = "")
     {
-        if(!is_string($uri)) throw new \InvalidArgumentException("Embed::__construct first argument \$uri must be a string. Given: ".($uri ? "$uri " : "")."(".gettype($uri).").");
+        if(!is_string($uri)) throw new \InvalidArgumentException(__METHOD__." first argument \$uri must be a string. Given: ".($uri ? "$uri " : "")."(".gettype($uri).").");
         $uri = trim($uri);
-        if(preg_match('/\s/', $uri)) throw new \InvalidArgumentException("Embed::__construct first argument \$uri must not contain whitespace. Given: \"".str_replace("\n", "\\n", $uri)."\".");
+        if(preg_match('/\s/', $uri)) throw new \InvalidArgumentException(__METHOD__." first argument \$uri must not contain whitespace. Given: \"".str_replace("\n", "\\n", $uri)."\".");
         $this->uri = self::convertHttpToHttps($uri);
 
-        if(!is_string($subtype)) throw new \InvalidArgumentException("Embed::__construct second argument \$subtype must be a string. Given: ".($subtype ? "$subtype " : "")."(".gettype($subtype).").");
+        if(!is_string($subtype)) throw new \InvalidArgumentException(__METHOD__." second argument \$subtype must be a string. Given: ".($subtype ? "$subtype " : "")."(".gettype($subtype).").");
         $this->subtype = $subtype;
-        if(!is_string($caption)) throw new \InvalidArgumentException("Embed::__construct third argument \$caption must be a string. Given: ".($caption ? "$caption " : "")."(".gettype($caption).").");
+        if(!is_string($caption)) throw new \InvalidArgumentException(__METHOD__." third argument \$caption must be a string. Given: ".($caption ? "$caption " : "")."(".gettype($caption).").");
         $this->caption = $caption;
     }
 

--- a/src/Embed.php
+++ b/src/Embed.php
@@ -20,9 +20,9 @@ class Embed implements CopilotTag
         if(preg_match('/\s/', $uri)) throw new \InvalidArgumentException("Embed::__construct first argument \$uri must not contain whitespace. Given: \"".str_replace("\n", "\\n", $uri)."\".");
         $this->uri = self::convertHttpToHttps($uri);
 
-        if (!is_string($subtype)) throw new \InvalidArgumentException("Embed::__construct second argument \$subtype must be a string. Given: ".($subtype ? "$subtype " : "")."(".gettype($subtype).").");
+        if(!is_string($subtype)) throw new \InvalidArgumentException("Embed::__construct second argument \$subtype must be a string. Given: ".($subtype ? "$subtype " : "")."(".gettype($subtype).").");
         $this->subtype = $subtype;
-        if (!is_string($caption)) throw new \InvalidArgumentException("Embed::__construct third argument \$caption must be a string. Given: ".($caption ? "$caption " : "")."(".gettype($caption).").");
+        if(!is_string($caption)) throw new \InvalidArgumentException("Embed::__construct third argument \$caption must be a string. Given: ".($caption ? "$caption " : "")."(".gettype($caption).").");
         $this->caption = $caption;
     }
 

--- a/src/Embed.php
+++ b/src/Embed.php
@@ -28,8 +28,8 @@ class Embed implements CopilotTag
 
     public function write()
     {
-        if($this->uri === "") return "";
-        $caption = $this->caption !== "" ? "|||$this->caption|||" : "";
+        if($this->uri == "") return "";
+        $caption = $this->caption != "" ? "|||$this->caption|||" : "";
         return "\n\n[#$this->subtype:$this->uri]$caption\n";
     }
 

--- a/src/Embed.php
+++ b/src/Embed.php
@@ -15,9 +15,9 @@ class Embed implements CopilotTag
 
     public function __construct($uri, $subtype = EmbedSubtype::IFRAME, $caption = "")
     {
-        if (!is_string($uri)) throw new \InvalidArgumentException("Embed::__construct first argument \$uri must be a string. Given: ".($uri ? "$uri " : "")."(".gettype($uri).").");
+        if(!is_string($uri)) throw new \InvalidArgumentException("Embed::__construct first argument \$uri must be a string. Given: ".($uri ? "$uri " : "")."(".gettype($uri).").");
         $uri = trim($uri);
-        if (preg_match('/\s/', $uri)) throw new \InvalidArgumentException("Embed::__construct first argument \$uri must not contain whitespace. Given: \"".str_replace("\n", "\\n", $uri)."\".");
+        if(preg_match('/\s/', $uri)) throw new \InvalidArgumentException("Embed::__construct first argument \$uri must not contain whitespace. Given: \"".str_replace("\n", "\\n", $uri)."\".");
         $this->uri = self::convertHttpToHttps($uri);
 
         if (!is_string($subtype)) throw new \InvalidArgumentException("Embed::__construct second argument \$subtype must be a string. Given: ".($subtype ? "$subtype " : "")."(".gettype($subtype).").");
@@ -28,7 +28,7 @@ class Embed implements CopilotTag
 
     public function write()
     {
-        if ($this->uri === "") return "";
+        if($this->uri === "") return "";
         $caption = $this->caption !== "" ? "|||$this->caption|||" : "";
         return "\n\n[#$this->subtype:$this->uri]$caption\n";
     }

--- a/src/Heading.php
+++ b/src/Heading.php
@@ -17,7 +17,7 @@ class Heading extends Text
     {
         parent::__construct($text);
 
-        if(!is_int($level)) throw new \InvalidArgumentException("Heading::__construct second argument \$level must be an int. Given: ".($level ? "$level " : "")."(".gettype($level).").");
+        if(!is_int($level)) throw new \InvalidArgumentException(__METHOD__." second argument \$level must be an int. Given: ".($level ? "$level " : "")."(".gettype($level).").");
         if($level < self::MIN_LEVEL) $this->level = self::MIN_LEVEL;
         else if($level > self::MAX_LEVEL) $this->level = self::MAX_LEVEL;
         else $this->level = $level;

--- a/src/Heading.php
+++ b/src/Heading.php
@@ -17,20 +17,20 @@ class Heading extends Text
     {
         parent::__construct($text);
 
-        if (!is_int($level)) throw new \InvalidArgumentException("Heading::__construct second argument \$level must be an int. Given: ".($level ? "$level " : "")."(".gettype($level).").");
-        if ($level < self::MIN_LEVEL) $this->level = self::MIN_LEVEL;
-        else if ($level > self::MAX_LEVEL) $this->level = self::MAX_LEVEL;
+        if(!is_int($level)) throw new \InvalidArgumentException("Heading::__construct second argument \$level must be an int. Given: ".($level ? "$level " : "")."(".gettype($level).").");
+        if($level < self::MIN_LEVEL) $this->level = self::MIN_LEVEL;
+        else if($level > self::MAX_LEVEL) $this->level = self::MAX_LEVEL;
         else $this->level = $level;
     }
 
     public function write()
     {
         $tag = $this->text;
-        if (trim($tag) !== "") {
+        if(trim($tag) !== "") {
             $levelString = str_repeat("#", $this->level);
             $tag = "$levelString $tag";
         }
-        if ($tag !== "") $tag = "$tag\n";
+        if($tag !== "") $tag = "$tag\n";
         return self::beautify($tag);
     }
 }

--- a/src/InlineText.php
+++ b/src/InlineText.php
@@ -23,16 +23,16 @@ class InlineText extends Text
     public function write()
     {
         $tag = $this->text;
-        if (!trim($tag)) return $tag;
+        if(!trim($tag)) return $tag;
 
         // Put embeds on their own lines
         $tag = preg_replace(Embed::EMBED_PATTERN, "\n$0\n", $tag);
 
         // Generate each line individually
-        if (preg_match("/\n/", $tag)) {
+        if(preg_match("/\n/", $tag)) {
           $tag = explode("\n", $tag);
           $tag = array_map(function ($splitTag) {
-            if (preg_match(Embed::EMBED_PATTERN, $splitTag)) return $splitTag;// Don't wrap embeds
+            if(preg_match(Embed::EMBED_PATTERN, $splitTag)) return $splitTag;// Don't wrap embeds
             return (new InlineText($splitTag, $this->delimiter))->write();
           }, $tag);
           $tag = implode("\n", $tag);

--- a/src/InlineText.php
+++ b/src/InlineText.php
@@ -16,7 +16,7 @@ class InlineText extends Text
     public function __construct($text, $delimiter = "")
     {
         parent::__construct($text);
-        if (!is_string($delimiter)) throw new \InvalidArgumentException("InlineText::__construct second argument \$delimiter must be a string. Given: ".($delimiter ? "$delimiter " : "")."(".gettype($delimiter).").");
+        if(!is_string($delimiter)) throw new \InvalidArgumentException("InlineText::__construct second argument \$delimiter must be a string. Given: ".($delimiter ? "$delimiter " : "")."(".gettype($delimiter).").");
         $this->delimiter = $delimiter;
     }
 
@@ -31,7 +31,7 @@ class InlineText extends Text
         // Generate each line individually
         if(preg_match("/\n/", $tag)) {
           $tag = explode("\n", $tag);
-          $tag = array_map(function ($splitTag) {
+          $tag = array_map(function($splitTag) {
             if(preg_match(Embed::EMBED_PATTERN, $splitTag)) return $splitTag;// Don't wrap embeds
             return (new InlineText($splitTag, $this->delimiter))->write();
           }, $tag);

--- a/src/InlineText.php
+++ b/src/InlineText.php
@@ -16,7 +16,7 @@ class InlineText extends Text
     public function __construct($text, $delimiter = "")
     {
         parent::__construct($text);
-        if(!is_string($delimiter)) throw new \InvalidArgumentException("InlineText::__construct second argument \$delimiter must be a string. Given: ".($delimiter ? "$delimiter " : "")."(".gettype($delimiter).").");
+        if(!is_string($delimiter)) throw new \InvalidArgumentException(__METHOD__." second argument \$delimiter must be a string. Given: ".($delimiter ? "$delimiter " : "")."(".gettype($delimiter).").");
         $this->delimiter = $delimiter;
     }
 

--- a/src/InlineText.php
+++ b/src/InlineText.php
@@ -11,7 +11,6 @@ namespace CopilotTags;
  */
 class InlineText extends Text
 {
-
     private $delimiter;
 
     public function __construct($text, $delimiter = "")
@@ -23,7 +22,7 @@ class InlineText extends Text
 
     public function write()
     {
-        $tag = parent::write();
+        $tag = $this->text;
         if (!trim($tag)) return $tag;
 
         // Put embeds on their own lines

--- a/src/Link.php
+++ b/src/Link.php
@@ -12,12 +12,12 @@ class Link extends Text
     {
         parent::__construct($text);
 
-        if(!is_string($href)) throw new \InvalidArgumentException("Link::__construct second argument \$href must be a string. Given: ".($href ? "$href " : "")."(".gettype($href).").");
+        if(!is_string($href)) throw new \InvalidArgumentException(__METHOD__." second argument \$href must be a string. Given: ".($href ? "$href " : "")."(".gettype($href).").");
         $href = trim($href);
-        if(preg_match('/\s/', $href)) throw new \InvalidArgumentException("Link::__construct second argument \$href must not contain whitespace. Given: \"".str_replace("\n", "\\n", $href)."\".");
+        if(preg_match('/\s/', $href)) throw new \InvalidArgumentException(__METHOD__." second argument \$href must not contain whitespace. Given: \"".str_replace("\n", "\\n", $href)."\".");
         $this->href = $href;
 
-        if(!is_array($attributes)) throw new \InvalidArgumentException("Link::__construct third argument \$attributes must be an array. Given: ".($attributes ? "$attributes " : "")."(".gettype($attributes).").");
+        if(!is_array($attributes)) throw new \InvalidArgumentException(__METHOD__." third argument \$attributes must be an array. Given: ".($attributes ? "$attributes " : "")."(".gettype($attributes).").");
         $this->attributes = $attributes;
     }
 

--- a/src/Link.php
+++ b/src/Link.php
@@ -55,8 +55,9 @@ class Link extends Text
         return self::beautify("{$lwspace}[$text]($href){$attrs}{$rwspace}");
     }
 
-    static function beautify($md = "") {
-        $md = preg_replace("/\]\(.*\)\s*\[([^#])/", " $1", $md);
-        return parent::beautify($md);
+    public static function beautify($markdown) {
+        // convert multiple links with whitespace between them to a single link
+        $markdown = preg_replace("/\]\(.*\)\s*\[([^#])/", " $1", $markdown);
+        return parent::beautify($markdown);
     }
 }

--- a/src/Link.php
+++ b/src/Link.php
@@ -12,9 +12,9 @@ class Link extends Text
     {
         parent::__construct($text);
 
-        if (!is_string($href)) throw new \InvalidArgumentException("Link::__construct second argument \$href must be a string. Given: ".($href ? "$href " : "")."(".gettype($href).").");
+        if(!is_string($href)) throw new \InvalidArgumentException("Link::__construct second argument \$href must be a string. Given: ".($href ? "$href " : "")."(".gettype($href).").");
         $href = trim($href);
-        if (preg_match('/\s/', $href)) throw new \InvalidArgumentException("Link::__construct second argument \$href must not contain whitespace. Given: \"".str_replace("\n", "\\n", $href)."\".");
+        if(preg_match('/\s/', $href)) throw new \InvalidArgumentException("Link::__construct second argument \$href must not contain whitespace. Given: \"".str_replace("\n", "\\n", $href)."\".");
         $this->href = $href;
 
         if (!is_array($attributes)) throw new \InvalidArgumentException("Link::__construct third argument \$attributes must be an array. Given: ".($attributes ? "$attributes " : "")."(".gettype($attributes).").");
@@ -23,14 +23,14 @@ class Link extends Text
 
     public function write()
     {
-        if ($this->text == "") return self::beautify($this->text);
+        if($this->text == "") return self::beautify($this->text);
 
         // Generate each line individually
-        if (preg_match("/\n/", $this->text)) {
+        if(preg_match("/\n/", $this->text)) {
             $tags = explode("\n", $this->text);
             $tags = array_map(function($tag) {
-              if (preg_match(Embed::EMBED_PATTERN, $tag)) return $tag;// Don't wrap embeds
-              if (!trim($tag)) return $tag;
+              if(preg_match(Embed::EMBED_PATTERN, $tag)) return $tag;// Don't wrap embeds
+              if(!trim($tag)) return $tag;
               return (new Link($tag, $this->href, $this->attributes))->write();
             }, $tags);
             $tags = implode("\n", $tags);
@@ -46,7 +46,7 @@ class Link extends Text
         $href = preg_replace("/\n/", "", $this->href);
 
         $attrs = "";
-        if ($this->attributes) {
+        if($this->attributes) {
             foreach($this->attributes as $key => $value) {
                 $attrs = "$attrs $key=\"$value\"";
             }

--- a/src/Link.php
+++ b/src/Link.php
@@ -17,7 +17,7 @@ class Link extends Text
         if(preg_match('/\s/', $href)) throw new \InvalidArgumentException("Link::__construct second argument \$href must not contain whitespace. Given: \"".str_replace("\n", "\\n", $href)."\".");
         $this->href = $href;
 
-        if (!is_array($attributes)) throw new \InvalidArgumentException("Link::__construct third argument \$attributes must be an array. Given: ".($attributes ? "$attributes " : "")."(".gettype($attributes).").");
+        if(!is_array($attributes)) throw new \InvalidArgumentException("Link::__construct third argument \$attributes must be an array. Given: ".($attributes ? "$attributes " : "")."(".gettype($attributes).").");
         $this->attributes = $attributes;
     }
 

--- a/src/ListTag.php
+++ b/src/ListTag.php
@@ -17,7 +17,7 @@ class ListTag implements CopilotTag
     public function __construct($items, $ordered = FALSE)
     {
         if(!is_array($items)) throw new \InvalidArgumentException("ListTag::__construct first argument \$items must be an array. Given: ".($items ? "$items " : "")."(".gettype($items).").");
-        foreach($items as $i=>$item) {
+        foreach($items as $i => $item) {
             if(!is_string($item)) throw new \InvalidArgumentException("ListTag::__construct first argument \$items must be an array of strings. Given \$items[$i] = ".($item ? "$item " : "")."(".(gettype($item)).").");
         }
         $this->items = $items;
@@ -30,7 +30,7 @@ class ListTag implements CopilotTag
         $item_indentation = $this->ordered ? "   " : "  ";
 
         $tag = "";
-        foreach($this->items as $i=>$item) {
+        foreach($this->items as $i => $item) {
             $text = new Text($item);
             $item = $text->write();
             $item = trim($item);

--- a/src/ListTag.php
+++ b/src/ListTag.php
@@ -29,25 +29,21 @@ class ListTag implements CopilotTag
     {
         $item_indentation = $this->ordered ? "   " : "  ";
 
-        $tag = "";
+        $list = "";
         foreach($this->items as $i => $item) {
             $text = new Text($item);
             $item = $text->write();
             $item = trim($item);
-
-            if($item === "") continue;
+            if($item == "") continue;
 
             // indent multiline content
             $item = preg_replace('/\n/', "\n$item_indentation", $item);
             // prefix with list marker
-            if($this->ordered) {
-                $item = strval($i + 1).self::LIST_MARKER_ORDERED." $item";
-            } else {
-                $item = self::LIST_MARKER_BULLET." $item";
-            }
-            $tag = "$tag$item\n";
+            if($this->ordered) $list_marker = strval($i + 1).self::LIST_MARKER_ORDERED;
+            else $list_marker = self::LIST_MARKER_BULLET;
+            $list = "$list$list_marker $item\n";
         }
-        if($tag !== "") $tag = "$tag\n";
-        return $tag;
+        if($list != "") $list = "$list\n";
+        return $list;
     }
 }

--- a/src/ListTag.php
+++ b/src/ListTag.php
@@ -16,12 +16,12 @@ class ListTag implements CopilotTag
 
     public function __construct($items, $ordered = FALSE)
     {
-        if(!is_array($items)) throw new \InvalidArgumentException("ListTag::__construct first argument \$items must be an array. Given: ".($items ? "$items " : "")."(".gettype($items).").");
+        if(!is_array($items)) throw new \InvalidArgumentException(__METHOD__." first argument \$items must be an array. Given: ".($items ? "$items " : "")."(".gettype($items).").");
         foreach($items as $i => $item) {
-            if(!is_string($item)) throw new \InvalidArgumentException("ListTag::__construct first argument \$items must be an array of strings. Given \$items[$i] = ".($item ? "$item " : "")."(".(gettype($item)).").");
+            if(!is_string($item)) throw new \InvalidArgumentException(__METHOD__." first argument \$items must be an array of strings. Given \$items[$i] = ".($item ? "$item " : "")."(".(gettype($item)).").");
         }
         $this->items = $items;
-        if(!is_bool($ordered)) throw new \InvalidArgumentException("ListTag::__construct second argument \$ordered must be a bool. Given: ".($ordered ? "$ordered " : "")."(".gettype($ordered).").");
+        if(!is_bool($ordered)) throw new \InvalidArgumentException(__METHOD__." second argument \$ordered must be a bool. Given: ".($ordered ? "$ordered " : "")."(".gettype($ordered).").");
         $this->ordered = $ordered;
     }
 

--- a/src/Paragraph.php
+++ b/src/Paragraph.php
@@ -10,7 +10,7 @@ class Paragraph extends Text
     public function write()
     {
         $tag = $this->text;
-        if ($tag !== "") $tag = "$tag\n\n";
+        if($tag !== "") $tag = "$tag\n\n";
         return self::beautify($tag);
     }
 }

--- a/src/Section.php
+++ b/src/Section.php
@@ -5,15 +5,10 @@ namespace CopilotTags;
  * Section
  * CFM spec: https://github.com/conde-nast-international/copilot-markdown/blob/master/specification/0E.md#313-section
  */
-class Section extends Text
+class Section implements CopilotTag
 {
-    public function __construct($text = "")
-    {
-        parent::__construct($text);
-    }
-
     public function write()
     {
-        return self::beautify("$this->text\n-=-=-=-\n");
+        return "\n-=-=-=-\n";
     }
 }

--- a/src/StringUtils.php
+++ b/src/StringUtils.php
@@ -3,13 +3,13 @@ namespace CopilotTags;
 
 class StringUtils
 {
-    static function leadingSpace($text = "") {
-        preg_match("/^\s+/", $text, $lwspace);
-        return implode("", $lwspace);
+    static function leadingSpace($str) {
+        preg_match("/^\s+/", $str, $lwspace);
+        return $lwspace[0];
     }
 
-    static function trailingSpace($text = "") {
-        preg_match("/\s+$/", $text, $rwspace);
-        return implode("", $rwspace);
+    static function trailingSpace($str) {
+        preg_match("/\s+$/", $str, $rwspace);
+        return $rwspace[0];
     }
 }

--- a/src/Text.php
+++ b/src/Text.php
@@ -7,7 +7,7 @@ class Text implements CopilotTag
 
     public function __construct($text)
     {
-        if(!is_string($text)) throw new \InvalidArgumentException("Text::__construct first argument \$text must be a string. Given: ".($text ? "$text " : "")."(".gettype($text).").");
+        if(!is_string($text)) throw new \InvalidArgumentException(__METHOD__." first argument \$text must be a string. Given: ".($text ? "$text " : "")."(".gettype($text).").");
         // convert newline types to LF newlines
         $text = preg_replace('/\R/', "\n", $text);
         $this->text = $text;

--- a/src/Text.php
+++ b/src/Text.php
@@ -7,7 +7,7 @@ class Text implements CopilotTag
 
     public function __construct($text)
     {
-        if (!is_string($text)) throw new \InvalidArgumentException("Text::__construct first argument \$text must be a string. Given: ".($text ? "$text " : "")."(".gettype($text).").");
+        if(!is_string($text)) throw new \InvalidArgumentException("Text::__construct first argument \$text must be a string. Given: ".($text ? "$text " : "")."(".gettype($text).").");
         // convert newline types to LF newlines
         $text = preg_replace('/\R/', "\n", $text);
         $this->text = $text;

--- a/tests/BlockquoteTest.php
+++ b/tests/BlockquoteTest.php
@@ -1,10 +1,10 @@
 <?php
-use CopilotTags\Tests\CopilotTagTest;
+namespace CopilotTags\Tests;
 use CopilotTags\Blockquote;
 
 class BlockquoteTest extends CopilotTagTest
 {
-    public function expectedWrites()
+    public static function expectedWrites()
     {
         return [
             "expect single text line" => [
@@ -46,33 +46,33 @@ class BlockquoteTest extends CopilotTagTest
         ];
     }
 
-    public function expectedConstructExceptions()
+    public static function expectedConstructExceptions()
     {
         return [
             "expect null \$text argument to throw InvalidArgumentException" => [
                 Blockquote::class,
                 [NULL],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean false \$text argument to throw InvalidArgumentException" => [
                 Blockquote::class,
                 [FALSE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean true \$text argument to throw InvalidArgumentException" => [
                 Blockquote::class,
                 [TRUE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect number \$text argument to throw InvalidArgumentException" => [
                 Blockquote::class,
                 [5],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect array \$text argument to throw InvalidArgumentException" => [
                 Blockquote::class,
                 [[]],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ]
         ];
     }

--- a/tests/CalloutTest.php
+++ b/tests/CalloutTest.php
@@ -1,10 +1,10 @@
 <?php
-use CopilotTags\Tests\CopilotTagTest;
+namespace CopilotTags\Tests;
 use CopilotTags\Callout;
 
 class CalloutTest extends CopilotTagTest
 {
-    public function expectedWrites()
+    public static function expectedWrites()
     {
         return [
             "expect text with subtype" => [
@@ -46,58 +46,58 @@ class CalloutTest extends CopilotTagTest
         ];
     }
 
-    public function expectedConstructExceptions()
+    public static function expectedConstructExceptions()
     {
         return [
             "expect null \$text argument to throw InvalidArgumentException" => [
                 Callout::class,
                 [NULL],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean false \$text argument to throw InvalidArgumentException" => [
                 Callout::class,
                 [FALSE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean true \$text argument to throw InvalidArgumentException" => [
                 Callout::class,
                 [TRUE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect number \$text argument to throw InvalidArgumentException" => [
                 Callout::class,
                 [5],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect array \$text argument to throw InvalidArgumentException" => [
                 Callout::class,
                 [[]],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect null \$subtype argument to throw InvalidArgumentException" => [
                 Callout::class,
                 ["", NULL],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean false \$subtype argument to throw InvalidArgumentException" => [
                 Callout::class,
                 ["", FALSE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean true \$subtype argument to throw InvalidArgumentException" => [
                 Callout::class,
                 ["", TRUE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect number \$subtype argument to throw InvalidArgumentException" => [
                 Callout::class,
                 ["", 5],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect array \$subtype argument to throw InvalidArgumentException" => [
                 Callout::class,
                 ["", []],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ]
         ];
     }

--- a/tests/CopilotTagTest.php
+++ b/tests/CopilotTagTest.php
@@ -22,6 +22,6 @@ abstract class CopilotTagTest extends TestCase
         new $class(...$args);
     }
 
-    public function expectedConstructExceptions() { return [[]]; }
-    abstract public function expectedWrites();
+    abstract public static function expectedWrites();
+    public static function expectedConstructExceptions() { return [[]]; }
 }

--- a/tests/CopilotTagTest.php
+++ b/tests/CopilotTagTest.php
@@ -17,7 +17,7 @@ abstract class CopilotTagTest extends TestCase
      */
     public function testConstructException($class = NULL, $args = [], $exceptionType = Exception::class)
     {
-        if (!isset($class)) return;
+        if(!isset($class)) return;
         $this->expectException($exceptionType);
         new $class(...$args);
     }

--- a/tests/EmbedTest.php
+++ b/tests/EmbedTest.php
@@ -1,11 +1,11 @@
 <?php
-use CopilotTags\Tests\CopilotTagTest;
+namespace CopilotTags\Tests;
 use CopilotTags\Embed;
 use CopilotTags\EmbedSubtype;
 
 class EmbedTest extends CopilotTagTest
 {
-    public function expectedWrites()
+    public static function expectedWrites()
     {
         return [
             "expect embed with subtype" => [
@@ -79,93 +79,93 @@ class EmbedTest extends CopilotTagTest
         ];
     }
 
-    public function expectedConstructExceptions()
+    public static function expectedConstructExceptions()
     {
         return [
             "expect null \$uri argument to throw InvalidArgumentException" => [
                 Embed::class,
                 [NULL],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean false \$uri argument to throw InvalidArgumentException" => [
                 Embed::class,
                 [FALSE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean true \$uri argument to throw InvalidArgumentException" => [
                 Embed::class,
                 [TRUE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect number \$uri argument to throw InvalidArgumentException" => [
                 Embed::class,
                 [5],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect array \$uri argument to throw InvalidArgumentException" => [
                 Embed::class,
                 [[]],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect \$uri argument with internal whitespace to throw InvalidArgumentException" => [
                 Embed::class,
                 ["http:// www.google.com"],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect \$uri argument with internal newline to throw InvalidArgumentException" => [
                 Embed::class,
                 ["http://\nwww.google.com"],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect null \$subtype argument to throw InvalidArgumentException" => [
                 Embed::class,
                 ["", NULL],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean false \$subtype argument to throw InvalidArgumentException" => [
                 Embed::class,
                 ["", FALSE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean true \$subtype argument to throw InvalidArgumentException" => [
                 Embed::class,
                 ["", TRUE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect number \$subtype argument to throw InvalidArgumentException" => [
                 Embed::class,
                 ["", 5],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect array \$subtype argument to throw InvalidArgumentException" => [
                 Embed::class,
                 ["", []],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect null \$caption argument to throw InvalidArgumentException" => [
                 Embed::class,
                 ["", "", NULL],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean false \$caption argument to throw InvalidArgumentException" => [
                 Embed::class,
                 ["", "", FALSE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean true \$caption argument to throw InvalidArgumentException" => [
                 Embed::class,
                 ["", "", TRUE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect number \$caption argument to throw InvalidArgumentException" => [
                 Embed::class,
                 ["", "", 5],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect array \$caption argument to throw InvalidArgumentException" => [
                 Embed::class,
                 ["", "", []],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ]
         ];
     }

--- a/tests/HRTest.php
+++ b/tests/HRTest.php
@@ -1,10 +1,10 @@
 <?php
-use CopilotTags\Tests\CopilotTagTest;
+namespace CopilotTags\Tests;
 use CopilotTags\HR;
 
 class HRTest extends CopilotTagTest
 {
-    public function expectedWrites()
+    public static function expectedWrites()
     {
         return [
             "expect HR" => [

--- a/tests/HeadingTest.php
+++ b/tests/HeadingTest.php
@@ -1,10 +1,10 @@
 <?php
-use CopilotTags\Tests\CopilotTagTest;
+namespace CopilotTags\Tests;
 use CopilotTags\Heading;
 
 class HeadingTest extends CopilotTagTest
 {
-    public function expectedWrites()
+    public static function expectedWrites()
     {
         return [
             "expect text with heading level" => [
@@ -34,58 +34,58 @@ class HeadingTest extends CopilotTagTest
         ];
     }
 
-    public function expectedConstructExceptions()
+    public static function expectedConstructExceptions()
     {
         return [
             "expect null \$text argument to throw InvalidArgumentException" => [
                 Heading::class,
                 [NULL],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean false \$text argument to throw InvalidArgumentException" => [
                 Heading::class,
                 [FALSE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean true \$text argument to throw InvalidArgumentException" => [
                 Heading::class,
                 [TRUE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect number \$text argument to throw InvalidArgumentException" => [
                 Heading::class,
                 [5],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect array \$text argument to throw InvalidArgumentException" => [
                 Heading::class,
                 [[]],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect null \$level argument to throw InvalidArgumentException" => [
                 Heading::class,
                 ["", NULL],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean false \$level argument to throw InvalidArgumentException" => [
                 Heading::class,
                 ["", FALSE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean true \$level argument to throw InvalidArgumentException" => [
                 Heading::class,
                 ["", TRUE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect array \$level argument to throw InvalidArgumentException" => [
                 Heading::class,
                 ["", []],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect string \$level argument to throw InvalidArgumentException" => [
                 Heading::class,
                 ["", "Hello world!"],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ]
         ];
     }

--- a/tests/InlineTextTest.php
+++ b/tests/InlineTextTest.php
@@ -1,10 +1,10 @@
 <?php
-use CopilotTags\Tests\CopilotTagTest;
+namespace CopilotTags\Tests;
 use CopilotTags\InlineText;
 
 class InlineTextTest extends CopilotTagTest
 {
-    public function expectedWrites()
+    public static function expectedWrites()
     {
         return [
             "expect empty string" => [
@@ -54,58 +54,58 @@ class InlineTextTest extends CopilotTagTest
         ];
     }
 
-    public function expectedConstructExceptions()
+    public static function expectedConstructExceptions()
     {
         return [
             "expect null \$text argument to throw InvalidArgumentException" => [
                 InlineText::class,
                 [NULL],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean false \$text argument to throw InvalidArgumentException" => [
                 InlineText::class,
                 [FALSE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean true \$text argument to throw InvalidArgumentException" => [
                 InlineText::class,
                 [TRUE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect number \$text argument to throw InvalidArgumentException" => [
                 InlineText::class,
                 [5],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect array \$text argument to throw InvalidArgumentException" => [
                 InlineText::class,
                 [[]],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect null \$delimiter argument to throw InvalidArgumentException" => [
                 InlineText::class,
                 ["", NULL],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean false \$delimiter argument to throw InvalidArgumentException" => [
                 InlineText::class,
                 ["", FALSE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean true \$delimiter argument to throw InvalidArgumentException" => [
                 InlineText::class,
                 ["", TRUE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect number \$delimiter argument to throw InvalidArgumentException" => [
                 InlineText::class,
                 ["", 5],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect array \$delimiter argument to throw InvalidArgumentException" => [
                 InlineText::class,
                 ["", []],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ]
         ];
     }

--- a/tests/LinkTest.php
+++ b/tests/LinkTest.php
@@ -1,12 +1,12 @@
 <?php
-use CopilotTags\Tests\CopilotTagTest;
+namespace CopilotTags\Tests;
 use CopilotTags\Link;
 use CopilotTags\Embed;
 use CopilotTags\EmbedSubtype;
 
 class LinkTest extends CopilotTagTest
 {
-    public function expectedWrites()
+    public static function expectedWrites()
     {
         $embedMarkdown = (new Embed("/photos/123ID", EmbedSubtype::IMAGE, "some caption"))->write();
 
@@ -86,93 +86,93 @@ class LinkTest extends CopilotTagTest
         ];
     }
 
-    public function expectedConstructExceptions()
+    public static function expectedConstructExceptions()
     {
         return [
             "expect null \$text argument to throw InvalidArgumentException" => [
                 Link::class,
                 [NULL],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean false \$text argument to throw InvalidArgumentException" => [
                 Link::class,
                 [FALSE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean true \$text argument to throw InvalidArgumentException" => [
                 Link::class,
                 [TRUE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect number \$text argument to throw InvalidArgumentException" => [
                 Link::class,
                 [5],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect array \$text argument to throw InvalidArgumentException" => [
                 Link::class,
                 [[]],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect null \$href argument to throw InvalidArgumentException" => [
                 Link::class,
                 ["", NULL],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean false \$href argument to throw InvalidArgumentException" => [
                 Link::class,
                 ["", FALSE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean true \$href argument to throw InvalidArgumentException" => [
                 Link::class,
                 ["", TRUE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect number \$href argument to throw InvalidArgumentException" => [
                 Link::class,
                 ["", 5],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect array \$href argument to throw InvalidArgumentException" => [
                 Link::class,
                 ["", []],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect \$href argument with internal whitespace to throw InvalidArgumentException" => [
                 Link::class,
                 ["", "http://li .nk"],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect \$href argument with internal newline to throw InvalidArgumentException" => [
                 Link::class,
                 ["", "http://li\n.nk"],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect null \$attributes argument to throw InvalidArgumentException" => [
                 Link::class,
                 ["", "", NULL],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean false \$attributes argument to throw InvalidArgumentException" => [
                 Link::class,
                 ["", "", FALSE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean true \$attributes argument to throw InvalidArgumentException" => [
                 Link::class,
                 ["", "", TRUE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect number \$attributes argument to throw InvalidArgumentException" => [
                 Link::class,
                 ["", "", 5],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect string \$attributes argument to throw InvalidArgumentException" => [
                 Link::class,
                 ["", "", ""],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ]
         ];
     }

--- a/tests/ListTagTest.php
+++ b/tests/ListTagTest.php
@@ -1,11 +1,11 @@
 <?php
-use CopilotTags\Tests\CopilotTagTest;
+namespace CopilotTags\Tests;
 use CopilotTags\ListTag;
 use CopilotTags\ListItem;
 
 class ListTagTest extends CopilotTagTest
 {
-    public function expectedWrites()
+    public static function expectedWrites()
     {
         return [
             "expect unordered list with single item" => [
@@ -67,78 +67,78 @@ class ListTagTest extends CopilotTagTest
         ];
     }
 
-    public function expectedConstructExceptions()
+    public static function expectedConstructExceptions()
     {
         return [
             "expect null \$items argument to throw InvalidArgumentException" => [
                 ListTag::class,
                 [NULL],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean false \$items argument to throw InvalidArgumentException" => [
                 ListTag::class,
                 [FALSE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean true \$items argument to throw InvalidArgumentException" => [
                 ListTag::class,
                 [TRUE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect number \$items argument to throw InvalidArgumentException" => [
                 ListTag::class,
                 [5],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect string \$items argument to throw InvalidArgumentException" => [
                 ListTag::class,
                 ["Hello world!"],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect array of null \$items argument to throw InvalidArgumentException" => [
                 ListTag::class,
                 [[NULL, NULL]],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect array of boolean false \$items argument to throw InvalidArgumentException" => [
                 ListTag::class,
                 [[FALSE, FALSE]],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect array of boolean true \$items argument to throw InvalidArgumentException" => [
                 ListTag::class,
                 [[TRUE, TRUE]],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect array of number \$items argument to throw InvalidArgumentException" => [
                 ListTag::class,
                 [[5, 5]],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect array of array \$items argument to throw InvalidArgumentException" => [
                 ListTag::class,
                 [[[], []]],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect null \$ordered argument to throw InvalidArgumentException" => [
                 ListTag::class,
                 [[], NULL],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect number \$ordered argument to throw InvalidArgumentException" => [
                 ListTag::class,
                 [[], 5],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect array \$ordered argument to throw InvalidArgumentException" => [
                 ListTag::class,
                 [[], []],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect string \$ordered argument to throw InvalidArgumentException" => [
                 ListTag::class,
                 [[], "Hello world!"],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ]
         ];
     }

--- a/tests/ParagraphTest.php
+++ b/tests/ParagraphTest.php
@@ -1,10 +1,10 @@
 <?php
-use CopilotTags\Tests\CopilotTagTest;
+namespace CopilotTags\Tests;
 use CopilotTags\Paragraph;
 
 class ParagraphTest extends CopilotTagTest
 {
-    public function expectedWrites()
+    public static function expectedWrites()
     {
         return [
             "expect plain text" => [
@@ -22,33 +22,33 @@ class ParagraphTest extends CopilotTagTest
         ];
     }
 
-    public function expectedConstructExceptions()
+    public static function expectedConstructExceptions()
     {
         return [
             "expect null \$text argument to throw InvalidArgumentException" => [
                 Paragraph::class,
                 [NULL],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean false \$text argument to throw InvalidArgumentException" => [
                 Paragraph::class,
                 [FALSE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean true \$text argument to throw InvalidArgumentException" => [
                 Paragraph::class,
                 [TRUE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect number \$text argument to throw InvalidArgumentException" => [
                 Paragraph::class,
                 [5],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect array \$text argument to throw InvalidArgumentException" => [
                 Paragraph::class,
                 [[]],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ]
         ];
     }

--- a/tests/SectionTest.php
+++ b/tests/SectionTest.php
@@ -13,35 +13,4 @@ class SectionTest extends CopilotTagTest
             ]
         ];
     }
-
-    public function expectedConstructExceptions()
-    {
-        return [
-            "expect null \$text argument to throw InvalidArgumentException" => [
-                Section::class,
-                [NULL],
-                InvalidArgumentException::class
-            ],
-            "expect boolean false \$text argument to throw InvalidArgumentException" => [
-                Section::class,
-                [FALSE],
-                InvalidArgumentException::class
-            ],
-            "expect boolean true \$text argument to throw InvalidArgumentException" => [
-                Section::class,
-                [TRUE],
-                InvalidArgumentException::class
-            ],
-            "expect number \$text argument to throw InvalidArgumentException" => [
-                Section::class,
-                [5],
-                InvalidArgumentException::class
-            ],
-            "expect array \$text argument to throw InvalidArgumentException" => [
-                Section::class,
-                [[]],
-                InvalidArgumentException::class
-            ]
-        ];
-    }
 }

--- a/tests/SectionTest.php
+++ b/tests/SectionTest.php
@@ -7,19 +7,7 @@ class SectionTest extends CopilotTagTest
     public function expectedWrites()
     {
         return [
-            "expect plain text" => [
-                new Section("Hello world!"),
-                "Hello world!\n-=-=-=-\n"
-            ],
-            "expect only whitespace to be removed" => [
-                new Section("  "),
-                "\n-=-=-=-\n"
-            ],
-            "expect empty string" => [
-                new Section(""),
-                "\n-=-=-=-\n"
-            ],
-            "expect no text" => [
+            "expect section" => [
                 new Section(),
                 "\n-=-=-=-\n"
             ]

--- a/tests/SectionTest.php
+++ b/tests/SectionTest.php
@@ -1,10 +1,10 @@
 <?php
-use CopilotTags\Tests\CopilotTagTest;
+namespace CopilotTags\Tests;
 use CopilotTags\Section;
 
 class SectionTest extends CopilotTagTest
 {
-    public function expectedWrites()
+    public static function expectedWrites()
     {
         return [
             "expect section" => [

--- a/tests/TextTest.php
+++ b/tests/TextTest.php
@@ -1,10 +1,10 @@
 <?php
-use CopilotTags\Tests\CopilotTagTest;
+namespace CopilotTags\Tests;
 use CopilotTags\Text;
 
 class TextTest extends CopilotTagTest
 {
-    public function expectedWrites()
+    public static function expectedWrites()
     {
         return [
             "expect plain text" => [
@@ -58,33 +58,33 @@ class TextTest extends CopilotTagTest
         ];
     }
 
-    public function expectedConstructExceptions()
+    public static function expectedConstructExceptions()
     {
         return [
             "expect null \$text argument to throw InvalidArgumentException" => [
                 Text::class,
                 [NULL],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean false \$text argument to throw InvalidArgumentException" => [
                 Text::class,
                 [FALSE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect boolean true \$text argument to throw InvalidArgumentException" => [
                 Text::class,
                 [TRUE],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect number \$text argument to throw InvalidArgumentException" => [
                 Text::class,
                 [5],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ],
             "expect array \$text argument to throw InvalidArgumentException" => [
                 Text::class,
                 [[]],
-                InvalidArgumentException::class
+                \InvalidArgumentException::class
             ]
         ];
     }


### PR DESCRIPTION
Changes:
* Change variable names in various places (`Blockquote`, `InlineText`, `ListTag`, `StringUtils`).
* Simplify logic in `ListTag`.
* Make syntax consistent (arrow syntax, spacing in if statements etc.).
* Remove `$text` property from Section.
* Use double equals (`==`) rather than triple equals (`===`).
* Use `__METHOD__` in exception messages.
* Make `beautify` function headers consistent.
* Make test data provider functions static.
* Use `CopilotTags\Tests` namespace in tests.