### PR TITLE
improve block-level tag rendering

### DIFF
--- a/example/example.php
+++ b/example/example.php
@@ -5,6 +5,7 @@ use CopilotTags\Paragraph;
 use CopilotTags\Heading;
 use CopilotTags\InlineText;
 use CopilotTags\InlineTextDelimiter;
+use CopilotTags\Blockquote;
 use CopilotTags\Embed;
 use CopilotTags\EmbedSubtype;
 
@@ -104,6 +105,9 @@ function on_close_tag($parser, $name) {
             break;
         case 'STRIKE':
             $tag = new InlineText($text, InlineTextDelimiter::DELETE);
+            break;
+        case 'QUOTE':
+            $tag = new Blockquote($text);
             break;
         case 'EMBED-VIDEO':
             $tag = new Embed($text, EmbedSubtype::VIDEO);

--- a/example/example_body.xml
+++ b/example/example_body.xml
@@ -2,4 +2,6 @@
 <body>
 <section><h1>My First Heading</h1><p>My first paragraph. It makes use of a number of tags including <i>italics</i>, <b>bold</b> and <strike>strikethrough</strike>.</p></section>
 <section><h1>My Video Embed</h1><embed-video>https://www.youtube.com/embed/fx2Qk-QqhXw</embed-video></section>
+<section><h1>My Block Quote</h1><p>My first block quote: <quote>The city’s central computer told you?
+R2D2, you know better than to trust a strange computer!</quote></p></section>
 </body>

--- a/src/Blockquote.php
+++ b/src/Blockquote.php
@@ -9,7 +9,7 @@ class Blockquote extends Text
 {
     public function write()
     {
-        if($this->text == "") return self::beautify($this->text);
+        if($this->text == "") return "";
 
         $write_line = function($str) { return "> $str\n"; };
         $lines = explode("\n", $this->text);

--- a/src/Blockquote.php
+++ b/src/Blockquote.php
@@ -14,6 +14,8 @@ class Blockquote extends Text
         $write_line = function($str) { return "> $str\n"; };
         $lines = explode("\n", $this->text);
         $lines = array_map($write_line, $lines);
-        return self::beautify(implode("", $lines));
+
+        $blockquote = implode("", $lines);
+        return self::beautify("\n$blockquote");
     }
 }

--- a/src/Blockquote.php
+++ b/src/Blockquote.php
@@ -9,13 +9,14 @@ class Blockquote extends Text
 {
     public function write()
     {
-        if($this->text == "") return "";
-
-        $write_line = function($str) { return "> $str\n"; };
-        $lines = explode("\n", $this->text);
-        $lines = array_map($write_line, $lines);
-
-        $blockquote = implode("", $lines);
+        if($this->text != "") {
+            $write_line = function($str) { return "> $str\n"; };
+            $lines = explode("\n", $this->text);
+            $lines = array_map($write_line, $lines);
+            $blockquote = implode("", $lines);
+        } else {
+            $blockquote = "\n";
+        }
         return self::beautify("\n$blockquote");
     }
 }

--- a/src/Callout.php
+++ b/src/Callout.php
@@ -20,7 +20,7 @@ class Callout extends Text
     {
         $text = parent::write();
         if(trim($text) == "") return "";
-        $text = "+++$this->subtype\n$text\n+++\n";
+        $text = "\n\n+++$this->subtype\n$text\n+++\n\n";
         return self::beautify($text);
     }
 }

--- a/src/Callout.php
+++ b/src/Callout.php
@@ -18,9 +18,9 @@ class Callout extends Text
 
     public function write()
     {
-        $tag = $this->text;
-        if(trim($tag) !== "") $tag = "+++$this->subtype\n$tag\n+++";
-        if($tag !== "") $tag = "$tag\n";
-        return self::beautify($tag);
+        $text = parent::write();
+        if(trim($text) == "") return "";
+        $text = "+++$this->subtype\n$text\n+++\n";
+        return self::beautify($text);
     }
 }

--- a/src/Callout.php
+++ b/src/Callout.php
@@ -19,8 +19,8 @@ class Callout extends Text
     public function write()
     {
         $text = parent::write();
-        if(trim($text) == "") return "";
-        $text = "\n\n+++$this->subtype\n$text\n+++\n\n";
+        if(trim($text) != "") $text = "+++$this->subtype\n$text\n+++";
+        $text = "\n\n$text\n\n";
         return self::beautify($text);
     }
 }

--- a/src/Embed.php
+++ b/src/Embed.php
@@ -30,7 +30,7 @@ class Embed implements CopilotTag
     {
         if($this->uri == "") return "";
         $caption = $this->caption != "" ? "|||$this->caption|||" : "";
-        return "\n\n[#$this->subtype:$this->uri]$caption\n";
+        return "\n\n[#$this->subtype:$this->uri]$caption\n\n";
     }
 
     private static function convertHttpToHttps($url)

--- a/src/Heading.php
+++ b/src/Heading.php
@@ -25,12 +25,9 @@ class Heading extends Text
 
     public function write()
     {
-        $tag = $this->text;
-        if(trim($tag) !== "") {
-            $levelString = str_repeat("#", $this->level);
-            $tag = "$levelString $tag";
-        }
-        if($tag !== "") $tag = "$tag\n";
-        return self::beautify($tag);
+        $text = parent::write();
+        if(trim($text) == "") return "";
+        $levelString = str_repeat("#", $this->level);
+        return self::beautify("$levelString $text\n");
     }
 }

--- a/src/Heading.php
+++ b/src/Heading.php
@@ -28,6 +28,6 @@ class Heading extends Text
         $text = parent::write();
         if(trim($text) == "") return "";
         $levelString = str_repeat("#", $this->level);
-        return self::beautify("$levelString $text\n");
+        return self::beautify("\n\n$levelString $text\n");
     }
 }

--- a/src/Heading.php
+++ b/src/Heading.php
@@ -26,8 +26,11 @@ class Heading extends Text
     public function write()
     {
         $text = parent::write();
-        if(trim($text) == "") return "";
-        $levelString = str_repeat("#", $this->level);
-        return self::beautify("\n\n$levelString $text\n");
+        if(trim($text) != "") {
+            $levelString = str_repeat("#", $this->level);
+            $text = "$levelString $text";
+        }
+        $text = "\n\n$text\n";
+        return self::beautify($text);
     }
 }

--- a/src/ListTag.php
+++ b/src/ListTag.php
@@ -43,7 +43,7 @@ class ListTag implements CopilotTag
             else $list_marker = self::LIST_MARKER_BULLET;
             $list = "$list$list_marker $item\n";
         }
-        if($list != "") $list = "$list\n";
+        if($list != "") $list = "\n\n$list\n";
         return $list;
     }
 }

--- a/src/Paragraph.php
+++ b/src/Paragraph.php
@@ -10,7 +10,7 @@ class Paragraph extends Text
     public function write()
     {
         $text = parent::write();
-        if(trim($text) == "") return "";
-        return self::beautify("\n$text\n\n");
+        $text = "\n$text\n\n";
+        return self::beautify($text);
     }
 }

--- a/src/Paragraph.php
+++ b/src/Paragraph.php
@@ -10,7 +10,7 @@ class Paragraph extends Text
     public function write()
     {
         $text = parent::write();
-        $text = "\n$text\n\n";
+        $text = "\n\n$text\n\n";
         return self::beautify($text);
     }
 }

--- a/src/Paragraph.php
+++ b/src/Paragraph.php
@@ -11,6 +11,6 @@ class Paragraph extends Text
     {
         $text = parent::write();
         if(trim($text) == "") return "";
-        return self::beautify("$text\n\n");
+        return self::beautify("\n$text\n\n");
     }
 }

--- a/src/Paragraph.php
+++ b/src/Paragraph.php
@@ -9,8 +9,8 @@ class Paragraph extends Text
 {
     public function write()
     {
-        $tag = $this->text;
-        if($tag !== "") $tag = "$tag\n\n";
-        return self::beautify($tag);
+        $text = parent::write();
+        if(trim($text) == "") return "";
+        return self::beautify("$text\n\n");
     }
 }

--- a/tests/BlockquoteTest.php
+++ b/tests/BlockquoteTest.php
@@ -25,7 +25,7 @@ class BlockquoteTest extends CopilotTagTest
             ],
             "expect empty string" => [
                 new Blockquote(""),
-                ""
+                "\n\n"
             ],
             "expect multiple lines of whitespace only to be preserved with spaces on the first line" => [
                 new Blockquote("  \n"),

--- a/tests/BlockquoteTest.php
+++ b/tests/BlockquoteTest.php
@@ -9,19 +9,19 @@ class BlockquoteTest extends CopilotTagTest
         return [
             "expect single text line" => [
                 new Blockquote("Hello world!"),
-                "> Hello world!\n"
+                "\n> Hello world!\n"
             ],
             "expect multiple text lines" => [
                 new Blockquote("The city’s central computer told you?\nR2D2,\nyou know better than to trust a strange computer!"),
-                "> The city’s central computer told you?\n> R2D2,\n> you know better than to trust a strange computer!\n"
+                "\n> The city’s central computer told you?\n> R2D2,\n> you know better than to trust a strange computer!\n"
             ],
             "expect multiple lines with leading and trailing whitespace preserved" => [
                 new Blockquote("\n\nThe city’s central computer told you?\nR2D2,\nyou know better than to trust a strange computer!\n"),
-                "> \n> \n> The city’s central computer told you?\n> R2D2,\n> you know better than to trust a strange computer!\n> \n"
+                "\n> \n> \n> The city’s central computer told you?\n> R2D2,\n> you know better than to trust a strange computer!\n> \n"
             ],
             "expect whitespace to be preserved" => [
                 new Blockquote("  "),
-                ">   \n"
+                "\n>   \n"
             ],
             "expect empty string" => [
                 new Blockquote(""),
@@ -29,19 +29,19 @@ class BlockquoteTest extends CopilotTagTest
             ],
             "expect multiple lines of whitespace only to be preserved with spaces on the first line" => [
                 new Blockquote("  \n"),
-                ">   \n> \n"
+                "\n>   \n> \n"
             ],
             "expect multiple lines of whitespace only to be preserved with spaces on the last line" => [
                 new Blockquote("\n  "),
-                "> \n>   \n"
+                "\n> \n>   \n"
             ],
             "expect a single newline to be preserved" => [
                 new Blockquote("\n"),
-                "> \n> \n"
+                "\n> \n> \n"
             ],
             "expect multiple newlines to be preserved" => [
                 new Blockquote("\n\n\n\n"),
-                "> \n> \n> \n> \n> \n"
+                "\n> \n> \n> \n> \n> \n"
             ]
         ];
     }

--- a/tests/CalloutTest.php
+++ b/tests/CalloutTest.php
@@ -19,29 +19,29 @@ class CalloutTest extends CopilotTagTest
                 new Callout("\n\nHello\nworld!\n"),
                 "\n\n+++\n\nHello\nworld!\n\n+++\n\n"
             ],
-            "expect only whitespace to be removed" => [
+            "expect only whitespace" => [
                 new Callout("  "),
-                ""
+                "\n\n"
             ],
             "expect empty string" => [
                 new Callout(""),
-                ""
+                "\n\n"
             ],
-            "expect multiple whitespace-only lines to be removed with spaces on the first line" => [
+            "expect multiple whitespace-only lines with spaces on the first line" => [
                 new Callout("  \n"),
-                ""
+                "\n\n"
             ],
-            "expect multiple whitespace-only lines to be removed with spaces on the last line" => [
+            "expect multiple whitespace-only lines with spaces on the last line" => [
                 new Callout("\n  "),
-                ""
+                "\n\n"
             ],
-            "expect single newline to be removed" => [
+            "expect single newline" => [
                 new Callout("\n"),
-                ""
+                "\n\n"
             ],
-            "expect more than 2 newlines to be removed" => [
+            "expect more than 2 newlines" => [
                 new Callout("\n\n\n\n"),
-                ""
+                "\n\n"
             ]
         ];
     }

--- a/tests/CalloutTest.php
+++ b/tests/CalloutTest.php
@@ -21,27 +21,27 @@ class CalloutTest extends CopilotTagTest
             ],
             "expect only whitespace to be removed" => [
                 new Callout("  "),
-                "\n"
+                ""
             ],
             "expect empty string" => [
                 new Callout(""),
                 ""
             ],
-            "expect spaces on the first line with no non-whitespace characters to be removed" => [
+            "expect multiple whitespace-only lines to be removed with spaces on the first line" => [
                 new Callout("  \n"),
-                "\n\n"
+                ""
             ],
-            "expect spaces on the last line with no non-whitespace characters to be removed" => [
+            "expect multiple whitespace-only lines to be removed with spaces on the last line" => [
                 new Callout("\n  "),
-                "\n\n"
+                ""
             ],
-            "expect single newline to be preserved" => [
+            "expect single newline to be removed" => [
                 new Callout("\n"),
-                "\n\n"
+                ""
             ],
-            "expect more than 2 newlines to become 2 newlines" => [
+            "expect more than 2 newlines to be removed" => [
                 new Callout("\n\n\n\n"),
-                "\n\n"
+                ""
             ]
         ];
     }

--- a/tests/CalloutTest.php
+++ b/tests/CalloutTest.php
@@ -9,15 +9,15 @@ class CalloutTest extends CopilotTagTest
         return [
             "expect text with subtype" => [
                 new Callout("Hello world!", "type"),
-                "+++type\nHello world!\n+++\n"
+                "\n\n+++type\nHello world!\n+++\n\n"
             ],
             "expect text without subtype" => [
                 new Callout("Hello world!"),
-                "+++\nHello world!\n+++\n"
+                "\n\n+++\nHello world!\n+++\n\n"
             ],
             "expect newlines to be preserved" => [
                 new Callout("\n\nHello\nworld!\n"),
-                "+++\n\nHello\nworld!\n\n+++\n"
+                "\n\n+++\n\nHello\nworld!\n\n+++\n\n"
             ],
             "expect only whitespace to be removed" => [
                 new Callout("  "),

--- a/tests/EmbedTest.php
+++ b/tests/EmbedTest.php
@@ -10,15 +10,15 @@ class EmbedTest extends CopilotTagTest
         return [
             "expect embed with subtype" => [
                 new Embed("https://www.google.com", EmbedSubtype::VIDEO),
-                "\n\n[#video:https://www.google.com]\n"
+                "\n\n[#video:https://www.google.com]\n\n"
             ],
             "expect embed with default subtype" => [
                 new Embed("https://www.google.com"),
-                "\n\n[#iframe:https://www.google.com]\n"
+                "\n\n[#iframe:https://www.google.com]\n\n"
             ],
             "expect embed with http uri converted to https" => [
                 new Embed("http://www.google.com"),
-                "\n\n[#iframe:https://www.google.com]\n"
+                "\n\n[#iframe:https://www.google.com]\n\n"
             ],
             "expect empty string" => [
                 new Embed(""),
@@ -26,35 +26,35 @@ class EmbedTest extends CopilotTagTest
             ],
             "expect embed with caption" => [
                 new Embed("https://www.google.com", EmbedSubtype::IFRAME, "some caption"),
-                "\n\n[#iframe:https://www.google.com]|||some caption|||\n"
+                "\n\n[#iframe:https://www.google.com]|||some caption|||\n\n"
             ],
             "expect image embed with caption and uri beginning with forward slash" => [
                 new Embed("/photos/123ID", EmbedSubtype::IMAGE, "some caption"),
-                "\n\n[#image:/photos/123ID]|||some caption|||\n"
+                "\n\n[#image:/photos/123ID]|||some caption|||\n\n"
             ],
             "expect embed with leading whitespace in uri trimmed" => [
                 new Embed(" https://www.google.com"),
-                "\n\n[#iframe:https://www.google.com]\n"
+                "\n\n[#iframe:https://www.google.com]\n\n"
             ],
             "expect embed with trailing whitespace in uri trimmed" => [
                 new Embed("https://www.google.com "),
-                "\n\n[#iframe:https://www.google.com]\n"
+                "\n\n[#iframe:https://www.google.com]\n\n"
             ],
             "expect embed with leading and trailing whitespace in uri trimmed" => [
                 new Embed(" https://www.google.com "),
-                "\n\n[#iframe:https://www.google.com]\n"
+                "\n\n[#iframe:https://www.google.com]\n\n"
             ],
             "expect embed with trailing newline in uri trimmed" => [
                 new Embed("https://www.google.com\n"),
-                "\n\n[#iframe:https://www.google.com]\n"
+                "\n\n[#iframe:https://www.google.com]\n\n"
             ],
             "expect embed with leading newline in uri trimmed" => [
                 new Embed("\nhttps://www.google.com"),
-                "\n\n[#iframe:https://www.google.com]\n"
+                "\n\n[#iframe:https://www.google.com]\n\n"
             ],
             "expect embed with leading and trailing newlines in uri trimmed" => [
                 new Embed("\nhttps://www.google.com\n"),
-                "\n\n[#iframe:https://www.google.com]\n"
+                "\n\n[#iframe:https://www.google.com]\n\n"
             ],
             "expect empty string for only whitespace in uri" => [
                 new Embed("  "),

--- a/tests/HeadingTest.php
+++ b/tests/HeadingTest.php
@@ -13,7 +13,7 @@ class HeadingTest extends CopilotTagTest
             ],
             "expect only whitespace to be removed" => [
                 new Heading("  "),
-                "\n"
+                ""
             ],
             "expect empty string" => [
                 new Heading(""),

--- a/tests/HeadingTest.php
+++ b/tests/HeadingTest.php
@@ -11,17 +11,17 @@ class HeadingTest extends CopilotTagTest
                 new Heading("Hello world!", 3),
                 "\n\n### Hello world!\n"
             ],
-            "expect only whitespace to be removed" => [
+            "expect only whitespace" => [
                 new Heading("  "),
-                ""
+                "\n\n"
             ],
             "expect empty string" => [
                 new Heading(""),
-                ""
+                "\n\n"
             ],
             "expect empty string with heading level" => [
                 new Heading("", 4),
-                ""
+                "\n\n"
             ],
             "expect text without heading level" => [
                 new Heading("Hello world!"),

--- a/tests/HeadingTest.php
+++ b/tests/HeadingTest.php
@@ -9,7 +9,7 @@ class HeadingTest extends CopilotTagTest
         return [
             "expect text with heading level" => [
                 new Heading("Hello world!", 3),
-                "### Hello world!\n"
+                "\n\n### Hello world!\n"
             ],
             "expect only whitespace to be removed" => [
                 new Heading("  "),
@@ -25,11 +25,11 @@ class HeadingTest extends CopilotTagTest
             ],
             "expect text without heading level" => [
                 new Heading("Hello world!"),
-                "## Hello world!\n"
+                "\n\n## Hello world!\n"
             ],
             "expect heading level below minimum to render at minimum" => [
                 new Heading("Hello world!", 1),
-                "## Hello world!\n"
+                "\n\n## Hello world!\n"
             ]
         ];
     }

--- a/tests/LinkTest.php
+++ b/tests/LinkTest.php
@@ -45,7 +45,7 @@ class LinkTest extends CopilotTagTest
             ],
             "expect only embed" => [
                 new Link($embedMarkdown, "http://li.nk"),
-                "\n\n[#image:/photos/123ID]|||some caption|||\n"
+                "\n\n[#image:/photos/123ID]|||some caption|||\n\n"
             ],
             "expect internal newline in text to be removed" => [
                 new Link("Hello\nworld!", "http://li.nk"),
@@ -53,23 +53,23 @@ class LinkTest extends CopilotTagTest
             ],
             "expect only multiple embeds" => [
                 new Link("{$embedMarkdown}{$embedMarkdown}", "http://li.nk"),
-                "\n\n[#image:/photos/123ID]|||some caption|||\n\n[#image:/photos/123ID]|||some caption|||\n"
+                "\n\n[#image:/photos/123ID]|||some caption|||\n\n[#image:/photos/123ID]|||some caption|||\n\n"
             ],
             "expect text with embed at start and end" => [
                 new Link("{$embedMarkdown}some text yo{$embedMarkdown}", "http://li.nk"),
-                "\n\n[#image:/photos/123ID]|||some caption|||\n[some text yo](http://li.nk)\n\n[#image:/photos/123ID]|||some caption|||\n"
+                "\n\n[#image:/photos/123ID]|||some caption|||\n\n[some text yo](http://li.nk)\n\n[#image:/photos/123ID]|||some caption|||\n\n"
             ],
             "expect text with embed at end" => [
                 new Link("some text yo $embedMarkdown", "http://li.nk"),
-                "[some text yo](http://li.nk) \n\n[#image:/photos/123ID]|||some caption|||\n"
+                "[some text yo](http://li.nk) \n\n[#image:/photos/123ID]|||some caption|||\n\n"
             ],
             "expect text with embed at start" => [
                 new Link("$embedMarkdown some text yo", "http://li.nk"),
-                "\n\n[#image:/photos/123ID]|||some caption|||\n [some text yo](http://li.nk)"
+                "\n\n[#image:/photos/123ID]|||some caption|||\n\n [some text yo](http://li.nk)"
             ],
             "expect text with embed" => [
                 new Link("this is $embedMarkdown some text yo", "http://li.nk"),
-                "[this is](http://li.nk) \n\n[#image:/photos/123ID]|||some caption|||\n [some text yo](http://li.nk)"
+                "[this is](http://li.nk) \n\n[#image:/photos/123ID]|||some caption|||\n\n [some text yo](http://li.nk)"
             ],
             "expect href with trailing whitespace trimmed" => [
                 new Link("Hello world!", "http://li.nk     "),

--- a/tests/ListTagTest.php
+++ b/tests/ListTagTest.php
@@ -10,27 +10,27 @@ class ListTagTest extends CopilotTagTest
         return [
             "expect unordered list with single item" => [
                 new ListTag(["Hello world!"], FALSE),
-                "* Hello world!\n\n"
+                "\n\n* Hello world!\n\n"
             ],
             "expect ordered list with single item" => [
                 new ListTag(["Hello world!"], TRUE),
-                "1. Hello world!\n\n"
+                "\n\n1. Hello world!\n\n"
             ],
             "expect default unordered list with single item" => [
                 new ListTag(["Hello world!"]),
-                "* Hello world!\n\n"
+                "\n\n* Hello world!\n\n"
             ],
             "expect unordered list with multiple items" => [
                 new ListTag(["Hello", "world!"], FALSE),
-                "* Hello\n* world!\n\n"
+                "\n\n* Hello\n* world!\n\n"
             ],
             "expect ordered list with multiple items" => [
                 new ListTag(["Hello", "world!"], TRUE),
-                "1. Hello\n2. world!\n\n"
+                "\n\n1. Hello\n2. world!\n\n"
             ],
             "expect default unordered list with multiple items" => [
                 new ListTag(["Hello", "world!"]),
-                "* Hello\n* world!\n\n"
+                "\n\n* Hello\n* world!\n\n"
             ],
             "expect only whitespace" => [
                 new ListTag(["   "]),
@@ -42,27 +42,27 @@ class ListTagTest extends CopilotTagTest
             ],
             "expect unordered list with single multiline item" => [
                 new ListTag(["Hello\nworld!"], FALSE),
-                "* Hello\n  world!\n\n"
+                "\n\n* Hello\n  world!\n\n"
             ],
             "expect ordered list with single multiline item" => [
                 new ListTag(["Hello\nworld!"], TRUE),
-                "1. Hello\n   world!\n\n"
+                "\n\n1. Hello\n   world!\n\n"
             ],
             "expect unordered list with multiple multiline items" => [
                 new ListTag(["Hello\nworld!", "Hello\nworld!"], FALSE),
-                "* Hello\n  world!\n* Hello\n  world!\n\n"
+                "\n\n* Hello\n  world!\n* Hello\n  world!\n\n"
             ],
             "expect ordered list with multiple multiline items" => [
                 new ListTag(["Hello\nworld!", "Hello\nworld!"], TRUE),
-                "1. Hello\n   world!\n2. Hello\n   world!\n\n"
+                "\n\n1. Hello\n   world!\n2. Hello\n   world!\n\n"
             ],
             "expect more than 2 newlines in unordered list item to be reduced to 2" => [
                 new ListTag(["Hello\n\n\n\nworld!"], FALSE),
-                "* Hello\n  \n  world!\n\n"
+                "\n\n* Hello\n  \n  world!\n\n"
             ],
             "expect more than 2 newlines in ordered list item to be reduced to 2" => [
                 new ListTag(["Hello\n\n\n\nworld!"], TRUE),
-                "1. Hello\n   \n   world!\n\n"
+                "\n\n1. Hello\n   \n   world!\n\n"
             ]
         ];
     }

--- a/tests/ParagraphTest.php
+++ b/tests/ParagraphTest.php
@@ -9,7 +9,7 @@ class ParagraphTest extends CopilotTagTest
         return [
             "expect plain text" => [
                 new Paragraph("Hello world!"),
-                "Hello world!\n\n"
+                "\nHello world!\n\n"
             ],
             "expect only whitespace to be removed" => [
                 new Paragraph("  "),

--- a/tests/ParagraphTest.php
+++ b/tests/ParagraphTest.php
@@ -11,9 +11,9 @@ class ParagraphTest extends CopilotTagTest
                 new Paragraph("Hello world!"),
                 "Hello world!\n\n"
             ],
-            "expect only whitespace" => [
+            "expect only whitespace to be removed" => [
                 new Paragraph("  "),
-                "\n\n"
+                ""
             ],
             "expect empty string" => [
                 new Paragraph(""),

--- a/tests/ParagraphTest.php
+++ b/tests/ParagraphTest.php
@@ -9,7 +9,7 @@ class ParagraphTest extends CopilotTagTest
         return [
             "expect plain text" => [
                 new Paragraph("Hello world!"),
-                "\nHello world!\n\n"
+                "\n\nHello world!\n\n"
             ],
             "expect only whitespace" => [
                 new Paragraph("  "),

--- a/tests/ParagraphTest.php
+++ b/tests/ParagraphTest.php
@@ -11,13 +11,13 @@ class ParagraphTest extends CopilotTagTest
                 new Paragraph("Hello world!"),
                 "\nHello world!\n\n"
             ],
-            "expect only whitespace to be removed" => [
+            "expect only whitespace" => [
                 new Paragraph("  "),
-                ""
+                "\n\n"
             ],
             "expect empty string" => [
                 new Paragraph(""),
-                ""
+                "\n\n"
             ]
         ];
     }


### PR DESCRIPTION
Fixes: https://app.clubhouse.io/condenastinternational/story/7574

Changes:
* ~~Changes block-level tags to render whitespace-only `$text` as empty string `""`.~~
* Changes block-level tags to always render at least 2 newlines (given empty or whitespace-only input).
* Adds preceding newlines when rendering block-level tags to ensure that they are interpreted as block-level.
* Other cleanup such as changing variable names in a few places.