### PR TITLE
fix StringUtils undefined offset notice

### DIFF
--- a/src/StringUtils.php
+++ b/src/StringUtils.php
@@ -4,12 +4,12 @@ namespace CopilotTags;
 class StringUtils
 {
     static function leadingSpace($str) {
-        preg_match("/^\s+/", $str, $lwspace);
+        preg_match("/^\s*/", $str, $lwspace);
         return $lwspace[0];
     }
 
     static function trailingSpace($str) {
-        preg_match("/\s+$/", $str, $rwspace);
+        preg_match("/\s*$/", $str, $rwspace);
         return $rwspace[0];
     }
 }


### PR DESCRIPTION
Fixes: https://app.clubhouse.io/condenastinternational/story/7698

```
php > $link = new CopilotTags\Link("Tugboat", "google.com");
php > echo $link->write();
PHP Notice:  Undefined offset: 0 in /Users/sjones/src/cfm-php-demo/vendor/conde-nast-international/copilot-markdown-generator/src/StringUtils.php on line 8

Notice: Undefined offset: 0 in /Users/sjones/src/cfm-php-demo/vendor/conde-nast-international/copilot-markdown-generator/src/StringUtils.php on line 8
PHP Notice:  Undefined offset: 0 in /Users/sjones/src/cfm-php-demo/vendor/conde-nast-international/copilot-markdown-generator/src/StringUtils.php on line 13

Notice: Undefined offset: 0 in /Users/sjones/src/cfm-php-demo/vendor/conde-nast-international/copilot-markdown-generator/src/StringUtils.php on line 13
[Tugboat](google.com)
```