### PR TITLE
semantic changes for v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Generator for inline text tags: [emphasis](https://github.com/conde-nast-interna
 |`STRONG`       |`**`  |Bold                       |
 |`SUBSCRIPT`    |`~`   |Inferior, sub              |
 |`SUPERSCRIPT`  |`^`   |Superior, super            |
-|`DELETE`       |`~~`  |Strikethrough, Strike, Del |
+|`DELETE`       |`~~`  |Strikethrough, strike, del |
 
 ### Link
 
@@ -192,7 +192,7 @@ Generator for [sections](https://github.com/conde-nast-international/copilot-mar
 
 ### ThematicBreak
 
-Generator for [thematic breaks](http://spec.commonmark.org/0.27/#thematic-breaks). Also known as HR.
+Generator for [thematic breaks](http://spec.commonmark.org/0.27/#thematic-breaks). Also known as horizontal rule or HR.
 
 ```php
 (new ThematicBreak())->render();

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ composer require conde-nast-international/copilot-markdown-generator
 use CopilotTags\Text;
 
 $tag = new Text("Hello world!");
-$markdown = $tag->write();
+$markdown = $tag->render();
 echo $markdown;
 // Hello world!
 ```
@@ -36,9 +36,9 @@ Classes in this library are namespaced in `CopilotTags` (e.g. `CopilotTags\Parag
 ### CopilotTag
 
 Interface for tag generator classes.
-* `CopilotTag->write()`
+* `CopilotTag->render()`
 
-  Write tag object as beautified Copilot-flavored Markdown string.<br>
+  Render tag object as beautified Copilot-flavored Markdown string.<br>
   **Return:** string (Markdown)
 
 ### Text
@@ -47,7 +47,7 @@ Generator for unformatted text. The given text value can contain any valid
 Copilot-flavored Markdown.
 
 ```php
-(new Text("Hello world!"))->write();
+(new Text("Hello world!"))->render();
 // "Hello world!"
 ```
 
@@ -59,7 +59,7 @@ Copilot-flavored Markdown.
 Generator for [ATX headings](http://spec.commonmark.org/0.27/#atx-headings).
 
 ```php
-(new Heading("Hello world!", 3))->write();
+(new Heading("Hello world!", 3))->render();
 // "### Hello world!\n"
 ```
 
@@ -72,7 +72,7 @@ Generator for [ATX headings](http://spec.commonmark.org/0.27/#atx-headings).
 Generator for [paragraphs](http://spec.commonmark.org/0.27/#paragraphs).
 
 ```php
-(new Paragraph("Hello world!"))->write();
+(new Paragraph("Hello world!"))->render();
 // "Hello world!\n\n"
 ```
 
@@ -85,7 +85,7 @@ Generator for inline text tags: [emphasis](https://github.com/conde-nast-interna
 [delete](https://github.com/conde-nast-international/copilot-markdown/blob/master/specification/0E.md#314-delete).
 
 ```php
-(new InlineText("Hello world!", InlineTextDelimiter::EMPHASIS))->write();
+(new InlineText("Hello world!", InlineTextDelimiter::EMPHASIS))->render();
 // "*Hello world!*"
 ```
 
@@ -108,9 +108,9 @@ Generator for inline text tags: [emphasis](https://github.com/conde-nast-interna
 Generator for [links](https://github.com/conde-nast-international/copilot-markdown/blob/master/specification/0E.md#317-link).
 
 ```php
-(new Link("Hello world!", "https://github.com/"))->write();
+(new Link("Hello world!", "https://github.com/"))->render();
 // "[Hello world!](https://github.com/)"
-(new Link("Hello world!", "https://github.com/", array("rel"=>"nofollow")))->write();
+(new Link("Hello world!", "https://github.com/", array("rel"=>"nofollow")))->render();
 // "[Hello world!](https://github.com/){: rel=\"nofollow\" }"
 ```
 
@@ -124,7 +124,7 @@ Generator for [links](https://github.com/conde-nast-international/copilot-markdo
 Generator for [block quotes](http://spec.commonmark.org/0.27/#block-quotes).
 
 ```php
-(new BlockQuote("Hello world!"))->write();
+(new BlockQuote("Hello world!"))->render();
 // "> Hello world!\n"
 ```
 
@@ -136,9 +136,9 @@ Generator for [block quotes](http://spec.commonmark.org/0.27/#block-quotes).
 Generator for [lists](http://spec.commonmark.org/0.27/#lists).
 
 ```php
-(new ListTag(["First", "Second"]))->write();
+(new ListTag(["First", "Second"]))->render();
 // "* First\n* Second\n\n"
-(new ListTag(["First", "Second"], TRUE))->write();
+(new ListTag(["First", "Second"], TRUE))->render();
 // "1. First\n2. Second\n\n"
 ```
 
@@ -151,9 +151,9 @@ Generator for [lists](http://spec.commonmark.org/0.27/#lists).
 Generator for [embeds](https://github.com/conde-nast-international/copilot-markdown/blob/master/specification/0E.md#311-embed).
 
 ```php
-(new Embed("https://github.com", EmbedSubtype::IFRAME))->write();
+(new Embed("https://github.com", EmbedSubtype::IFRAME))->render();
 // "\n\n[#iframe: https://github.com]\n"
-(new Embed("https://github.com", EmbedSubtype::IFRAME, "My caption."))->write();
+(new Embed("https://github.com", EmbedSubtype::IFRAME, "My caption."))->render();
 // "\n\n[#iframe: https://github.com]|||My caption.|||\n"
 ```
 
@@ -171,7 +171,7 @@ Class constants for valid embed [subtypes](https://github.com/conde-nast-interna
 Generator for [callouts](https://github.com/conde-nast-international/copilot-markdown/blob/master/specification/0E.md#312-callout).
 
 ```php
-(new Callout("Hello world!", "type"))->write();
+(new Callout("Hello world!", "type"))->render();
 // "+++type\nHello world!\n+++\n"
 ```
 
@@ -184,7 +184,7 @@ Generator for [callouts](https://github.com/conde-nast-international/copilot-mar
 Generator for [sections](https://github.com/conde-nast-international/copilot-markdown/blob/master/specification/0E.md#313-section).
 
 ```php
-(new Section())->write();
+(new Section())->render();
 // "\n-=-=-=-\n"
 ```
 
@@ -195,7 +195,7 @@ Generator for [sections](https://github.com/conde-nast-international/copilot-mar
 Generator for [thematic breaks](http://spec.commonmark.org/0.27/#thematic-breaks). Also known as HR.
 
 ```php
-(new ThematicBreak())->write();
+(new ThematicBreak())->render();
 // "\n----------\n"
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,16 +119,16 @@ Generator for [links](https://github.com/conde-nast-international/copilot-markdo
   ***href:*** string (default: `""`)<br>
   ***attributes:*** array (default: `[]`)
 
-### BlockQuote
+### Blockquote
 
 Generator for [block quotes](http://spec.commonmark.org/0.27/#block-quotes).
 
 ```php
-(new BlockQuote("Hello world!"))->render();
+(new Blockquote("Hello world!"))->render();
 // "> Hello world!\n"
 ```
 
-* `new BlockQuote($text)`<br>
+* `new Blockquote($text)`<br>
   ***text:*** string (Markdown)<br>
 
 ### ListTag

--- a/README.md
+++ b/README.md
@@ -119,16 +119,16 @@ Generator for [links](https://github.com/conde-nast-international/copilot-markdo
   ***href:*** string (default: `""`)<br>
   ***attributes:*** array (default: `[]`)
 
-### Blockquote
+### BlockQuote
 
 Generator for [block quotes](http://spec.commonmark.org/0.27/#block-quotes).
 
 ```php
-(new Blockquote("Hello world!"))->write();
+(new BlockQuote("Hello world!"))->write();
 // "> Hello world!\n"
 ```
 
-* `new Blockquote($text)`<br>
+* `new BlockQuote($text)`<br>
   ***text:*** string (Markdown)<br>
 
 ### ListTag
@@ -190,16 +190,16 @@ Generator for [sections](https://github.com/conde-nast-international/copilot-mar
 
 * `new Section()`
 
-### HR
+### ThematicBreak
 
-Generator for [thematic breaks](http://spec.commonmark.org/0.27/#thematic-breaks).
+Generator for [thematic breaks](http://spec.commonmark.org/0.27/#thematic-breaks). Also known as HR.
 
 ```php
-(new HR())->write();
+(new ThematicBreak())->write();
 // "\n----------\n"
 ```
 
-* `new HR()`
+* `new ThematicBreak()`
 
 ## See also
 

--- a/example/example.php
+++ b/example/example.php
@@ -5,7 +5,7 @@ use CopilotTags\Paragraph;
 use CopilotTags\Heading;
 use CopilotTags\InlineText;
 use CopilotTags\InlineTextDelimiter;
-use CopilotTags\BlockQuote;
+use CopilotTags\Blockquote;
 use CopilotTags\Embed;
 use CopilotTags\EmbedSubtype;
 
@@ -107,7 +107,7 @@ function on_close_tag($parser, $name) {
             $tag = new InlineText($text, InlineTextDelimiter::DELETE);
             break;
         case 'QUOTE':
-            $tag = new BlockQuote($text);
+            $tag = new Blockquote($text);
             break;
         case 'EMBED-VIDEO':
             $tag = new Embed($text, EmbedSubtype::VIDEO);

--- a/example/example.php
+++ b/example/example.php
@@ -115,7 +115,7 @@ function on_close_tag($parser, $name) {
         default:
             $tag = new Text($text);
     }
-    $tag_markdown = $tag->write();
+    $tag_markdown = $tag->render();
 
     $stack_index = count($markdown_stack) - 1;
     $markdown_stack[$stack_index] = $markdown_stack[$stack_index].$tag_markdown;

--- a/example/example.php
+++ b/example/example.php
@@ -5,7 +5,7 @@ use CopilotTags\Paragraph;
 use CopilotTags\Heading;
 use CopilotTags\InlineText;
 use CopilotTags\InlineTextDelimiter;
-use CopilotTags\Blockquote;
+use CopilotTags\BlockQuote;
 use CopilotTags\Embed;
 use CopilotTags\EmbedSubtype;
 
@@ -107,7 +107,7 @@ function on_close_tag($parser, $name) {
             $tag = new InlineText($text, InlineTextDelimiter::DELETE);
             break;
         case 'QUOTE':
-            $tag = new Blockquote($text);
+            $tag = new BlockQuote($text);
             break;
         case 'EMBED-VIDEO':
             $tag = new Embed($text, EmbedSubtype::VIDEO);

--- a/src/BlockQuote.php
+++ b/src/BlockQuote.php
@@ -7,12 +7,12 @@ namespace CopilotTags;
  */
 class BlockQuote extends Text
 {
-    public function write()
+    public function render()
     {
         if($this->text != "") {
-            $write_line = function($str) { return "> $str\n"; };
+            $render_line = function($str) { return "> $str\n"; };
             $lines = explode("\n", $this->text);
-            $lines = array_map($write_line, $lines);
+            $lines = array_map($render_line, $lines);
             $blockquote = implode("", $lines);
         } else {
             $blockquote = "\n";

--- a/src/BlockQuote.php
+++ b/src/BlockQuote.php
@@ -2,10 +2,10 @@
 namespace CopilotTags;
 
 /**
- * Blockquote
+ * Block quote
  * CommonMark spec: http://spec.commonmark.org/0.27/#block-quotes
  */
-class Blockquote extends Text
+class BlockQuote extends Text
 {
     public function write()
     {

--- a/src/Blockquote.php
+++ b/src/Blockquote.php
@@ -5,7 +5,7 @@ namespace CopilotTags;
  * Block quote
  * CommonMark spec: http://spec.commonmark.org/0.27/#block-quotes
  */
-class BlockQuote extends Text
+class Blockquote extends Text
 {
     public function render()
     {

--- a/src/Callout.php
+++ b/src/Callout.php
@@ -16,9 +16,9 @@ class Callout extends Text
         $this->subtype = $subtype;
     }
 
-    public function write()
+    public function render()
     {
-        $text = parent::write();
+        $text = parent::render();
         if(trim($text) != "") $text = "+++$this->subtype\n$text\n+++";
         $text = "\n\n$text\n\n";
         return self::beautify($text);

--- a/src/CopilotTag.php
+++ b/src/CopilotTag.php
@@ -3,5 +3,5 @@ namespace CopilotTags;
 
 interface CopilotTag
 {
-    public function write();
+    public function render();
 }

--- a/src/Embed.php
+++ b/src/Embed.php
@@ -26,7 +26,7 @@ class Embed implements CopilotTag
         $this->caption = $caption;
     }
 
-    public function write()
+    public function render()
     {
         if($this->uri == "") return "";
         $caption = $this->caption != "" ? "|||$this->caption|||" : "";

--- a/src/Heading.php
+++ b/src/Heading.php
@@ -23,9 +23,9 @@ class Heading extends Text
         else $this->level = $level;
     }
 
-    public function write()
+    public function render()
     {
-        $text = parent::write();
+        $text = parent::render();
         if(trim($text) != "") {
             $levelString = str_repeat("#", $this->level);
             $text = "$levelString $text";

--- a/src/InlineText.php
+++ b/src/InlineText.php
@@ -20,7 +20,7 @@ class InlineText extends Text
         $this->delimiter = $delimiter;
     }
 
-    public function write()
+    public function render()
     {
         $tag = $this->text;
         if(!trim($tag)) return $tag;
@@ -33,7 +33,7 @@ class InlineText extends Text
           $tag = explode("\n", $tag);
           $tag = array_map(function($splitTag) {
             if(preg_match(Embed::EMBED_PATTERN, $splitTag)) return $splitTag;// Don't wrap embeds
-            return (new InlineText($splitTag, $this->delimiter))->write();
+            return (new InlineText($splitTag, $this->delimiter))->render();
           }, $tag);
           $tag = implode("\n", $tag);
         } else {

--- a/src/Link.php
+++ b/src/Link.php
@@ -21,7 +21,7 @@ class Link extends Text
         $this->attributes = $attributes;
     }
 
-    public function write()
+    public function render()
     {
         if($this->text == "") return self::beautify($this->text);
 
@@ -31,7 +31,7 @@ class Link extends Text
             $tags = array_map(function($tag) {
               if(preg_match(Embed::EMBED_PATTERN, $tag)) return $tag;// Don't wrap embeds
               if(!trim($tag)) return $tag;
-              return (new Link($tag, $this->href, $this->attributes))->write();
+              return (new Link($tag, $this->href, $this->attributes))->render();
             }, $tags);
             $tags = implode("\n", $tags);
             return self::beautify($tags);

--- a/src/ListTag.php
+++ b/src/ListTag.php
@@ -25,14 +25,14 @@ class ListTag implements CopilotTag
         $this->ordered = $ordered;
     }
 
-    public function write()
+    public function render()
     {
         $item_indentation = $this->ordered ? "   " : "  ";
 
         $list = "";
         foreach($this->items as $i => $item) {
             $text = new Text($item);
-            $item = $text->write();
+            $item = $text->render();
             $item = trim($item);
             if($item == "") continue;
 

--- a/src/Paragraph.php
+++ b/src/Paragraph.php
@@ -7,9 +7,9 @@ namespace CopilotTags;
  */
 class Paragraph extends Text
 {
-    public function write()
+    public function render()
     {
-        $text = parent::write();
+        $text = parent::render();
         $text = "\n\n$text\n\n";
         return self::beautify($text);
     }

--- a/src/Section.php
+++ b/src/Section.php
@@ -7,7 +7,7 @@ namespace CopilotTags;
  */
 class Section implements CopilotTag
 {
-    public function write()
+    public function render()
     {
         return "\n-=-=-=-\n";
     }

--- a/src/Text.php
+++ b/src/Text.php
@@ -13,7 +13,7 @@ class Text implements CopilotTag
         $this->text = $text;
     }
 
-    public function write()
+    public function render()
     {
         return self::beautify($this->text);
     }

--- a/src/ThematicBreak.php
+++ b/src/ThematicBreak.php
@@ -5,7 +5,7 @@ namespace CopilotTags;
  * Thematic break
  * CommonMark spec: http://spec.commonmark.org/0.27/#thematic-breaks
  */
-class HR implements CopilotTag
+class ThematicBreak implements CopilotTag
 {
     public function write()
     {

--- a/src/ThematicBreak.php
+++ b/src/ThematicBreak.php
@@ -7,7 +7,7 @@ namespace CopilotTags;
  */
 class ThematicBreak implements CopilotTag
 {
-    public function write()
+    public function render()
     {
         return "\n----------\n";
     }

--- a/tests/BlockQuoteTest.php
+++ b/tests/BlockQuoteTest.php
@@ -1,46 +1,46 @@
 <?php
 namespace CopilotTags\Tests;
-use CopilotTags\Blockquote;
+use CopilotTags\BlockQuote;
 
-class BlockquoteTest extends CopilotTagTest
+class BlockQuoteTest extends CopilotTagTest
 {
     public static function expectedWrites()
     {
         return [
             "expect single text line" => [
-                new Blockquote("Hello world!"),
+                new BlockQuote("Hello world!"),
                 "\n> Hello world!\n"
             ],
             "expect multiple text lines" => [
-                new Blockquote("The city’s central computer told you?\nR2D2,\nyou know better than to trust a strange computer!"),
+                new BlockQuote("The city’s central computer told you?\nR2D2,\nyou know better than to trust a strange computer!"),
                 "\n> The city’s central computer told you?\n> R2D2,\n> you know better than to trust a strange computer!\n"
             ],
             "expect multiple lines with leading and trailing whitespace preserved" => [
-                new Blockquote("\n\nThe city’s central computer told you?\nR2D2,\nyou know better than to trust a strange computer!\n"),
+                new BlockQuote("\n\nThe city’s central computer told you?\nR2D2,\nyou know better than to trust a strange computer!\n"),
                 "\n> \n> \n> The city’s central computer told you?\n> R2D2,\n> you know better than to trust a strange computer!\n> \n"
             ],
             "expect whitespace to be preserved" => [
-                new Blockquote("  "),
+                new BlockQuote("  "),
                 "\n>   \n"
             ],
             "expect empty string" => [
-                new Blockquote(""),
+                new BlockQuote(""),
                 "\n\n"
             ],
             "expect multiple lines of whitespace only to be preserved with spaces on the first line" => [
-                new Blockquote("  \n"),
+                new BlockQuote("  \n"),
                 "\n>   \n> \n"
             ],
             "expect multiple lines of whitespace only to be preserved with spaces on the last line" => [
-                new Blockquote("\n  "),
+                new BlockQuote("\n  "),
                 "\n> \n>   \n"
             ],
             "expect a single newline to be preserved" => [
-                new Blockquote("\n"),
+                new BlockQuote("\n"),
                 "\n> \n> \n"
             ],
             "expect multiple newlines to be preserved" => [
-                new Blockquote("\n\n\n\n"),
+                new BlockQuote("\n\n\n\n"),
                 "\n> \n> \n> \n> \n> \n"
             ]
         ];
@@ -50,27 +50,27 @@ class BlockquoteTest extends CopilotTagTest
     {
         return [
             "expect null \$text argument to throw InvalidArgumentException" => [
-                Blockquote::class,
+                BlockQuote::class,
                 [NULL],
                 \InvalidArgumentException::class
             ],
             "expect boolean false \$text argument to throw InvalidArgumentException" => [
-                Blockquote::class,
+                BlockQuote::class,
                 [FALSE],
                 \InvalidArgumentException::class
             ],
             "expect boolean true \$text argument to throw InvalidArgumentException" => [
-                Blockquote::class,
+                BlockQuote::class,
                 [TRUE],
                 \InvalidArgumentException::class
             ],
             "expect number \$text argument to throw InvalidArgumentException" => [
-                Blockquote::class,
+                BlockQuote::class,
                 [5],
                 \InvalidArgumentException::class
             ],
             "expect array \$text argument to throw InvalidArgumentException" => [
-                Blockquote::class,
+                BlockQuote::class,
                 [[]],
                 \InvalidArgumentException::class
             ]

--- a/tests/BlockQuoteTest.php
+++ b/tests/BlockQuoteTest.php
@@ -4,7 +4,7 @@ use CopilotTags\BlockQuote;
 
 class BlockQuoteTest extends CopilotTagTest
 {
-    public static function expectedWrites()
+    public static function expectedRenders()
     {
         return [
             "expect single text line" => [

--- a/tests/BlockquoteTest.php
+++ b/tests/BlockquoteTest.php
@@ -1,46 +1,46 @@
 <?php
 namespace CopilotTags\Tests;
-use CopilotTags\BlockQuote;
+use CopilotTags\Blockquote;
 
-class BlockQuoteTest extends CopilotTagTest
+class BlockquoteTest extends CopilotTagTest
 {
     public static function expectedRenders()
     {
         return [
             "expect single text line" => [
-                new BlockQuote("Hello world!"),
+                new Blockquote("Hello world!"),
                 "\n> Hello world!\n"
             ],
             "expect multiple text lines" => [
-                new BlockQuote("The city’s central computer told you?\nR2D2,\nyou know better than to trust a strange computer!"),
+                new Blockquote("The city’s central computer told you?\nR2D2,\nyou know better than to trust a strange computer!"),
                 "\n> The city’s central computer told you?\n> R2D2,\n> you know better than to trust a strange computer!\n"
             ],
             "expect multiple lines with leading and trailing whitespace preserved" => [
-                new BlockQuote("\n\nThe city’s central computer told you?\nR2D2,\nyou know better than to trust a strange computer!\n"),
+                new Blockquote("\n\nThe city’s central computer told you?\nR2D2,\nyou know better than to trust a strange computer!\n"),
                 "\n> \n> \n> The city’s central computer told you?\n> R2D2,\n> you know better than to trust a strange computer!\n> \n"
             ],
             "expect whitespace to be preserved" => [
-                new BlockQuote("  "),
+                new Blockquote("  "),
                 "\n>   \n"
             ],
             "expect empty string" => [
-                new BlockQuote(""),
+                new Blockquote(""),
                 "\n\n"
             ],
             "expect multiple lines of whitespace only to be preserved with spaces on the first line" => [
-                new BlockQuote("  \n"),
+                new Blockquote("  \n"),
                 "\n>   \n> \n"
             ],
             "expect multiple lines of whitespace only to be preserved with spaces on the last line" => [
-                new BlockQuote("\n  "),
+                new Blockquote("\n  "),
                 "\n> \n>   \n"
             ],
             "expect a single newline to be preserved" => [
-                new BlockQuote("\n"),
+                new Blockquote("\n"),
                 "\n> \n> \n"
             ],
             "expect multiple newlines to be preserved" => [
-                new BlockQuote("\n\n\n\n"),
+                new Blockquote("\n\n\n\n"),
                 "\n> \n> \n> \n> \n> \n"
             ]
         ];
@@ -50,27 +50,27 @@ class BlockQuoteTest extends CopilotTagTest
     {
         return [
             "expect null \$text argument to throw InvalidArgumentException" => [
-                BlockQuote::class,
+                Blockquote::class,
                 [NULL],
                 \InvalidArgumentException::class
             ],
             "expect boolean false \$text argument to throw InvalidArgumentException" => [
-                BlockQuote::class,
+                Blockquote::class,
                 [FALSE],
                 \InvalidArgumentException::class
             ],
             "expect boolean true \$text argument to throw InvalidArgumentException" => [
-                BlockQuote::class,
+                Blockquote::class,
                 [TRUE],
                 \InvalidArgumentException::class
             ],
             "expect number \$text argument to throw InvalidArgumentException" => [
-                BlockQuote::class,
+                Blockquote::class,
                 [5],
                 \InvalidArgumentException::class
             ],
             "expect array \$text argument to throw InvalidArgumentException" => [
-                BlockQuote::class,
+                Blockquote::class,
                 [[]],
                 \InvalidArgumentException::class
             ]

--- a/tests/CalloutTest.php
+++ b/tests/CalloutTest.php
@@ -4,7 +4,7 @@ use CopilotTags\Callout;
 
 class CalloutTest extends CopilotTagTest
 {
-    public static function expectedWrites()
+    public static function expectedRenders()
     {
         return [
             "expect text with subtype" => [

--- a/tests/CopilotTagTest.php
+++ b/tests/CopilotTagTest.php
@@ -22,6 +22,6 @@ abstract class CopilotTagTest extends TestCase
         new $class(...$args);
     }
 
-    abstract public static function expectedRenders();
+    public static function expectedRenders() {}
     public static function expectedConstructExceptions() { return [[]]; }
 }

--- a/tests/CopilotTagTest.php
+++ b/tests/CopilotTagTest.php
@@ -5,11 +5,11 @@ use PHPUnit\Framework\TestCase;
 abstract class CopilotTagTest extends TestCase
 {
     /**
-     * @dataProvider expectedWrites
+     * @dataProvider expectedRenders
      */
-    public function testWrite($tag, $expected)
+    public function testRender($tag, $expected)
     {
-        $this->assertEquals($expected, $tag->write());
+        $this->assertEquals($expected, $tag->render());
     }
 
     /**
@@ -22,6 +22,6 @@ abstract class CopilotTagTest extends TestCase
         new $class(...$args);
     }
 
-    abstract public static function expectedWrites();
+    abstract public static function expectedRenders();
     public static function expectedConstructExceptions() { return [[]]; }
 }

--- a/tests/EmbedTest.php
+++ b/tests/EmbedTest.php
@@ -5,7 +5,7 @@ use CopilotTags\EmbedSubtype;
 
 class EmbedTest extends CopilotTagTest
 {
-    public static function expectedWrites()
+    public static function expectedRenders()
     {
         return [
             "expect embed with subtype" => [

--- a/tests/HeadingTest.php
+++ b/tests/HeadingTest.php
@@ -4,7 +4,7 @@ use CopilotTags\Heading;
 
 class HeadingTest extends CopilotTagTest
 {
-    public static function expectedWrites()
+    public static function expectedRenders()
     {
         return [
             "expect text with heading level" => [

--- a/tests/InlineTextTest.php
+++ b/tests/InlineTextTest.php
@@ -4,7 +4,7 @@ use CopilotTags\InlineText;
 
 class InlineTextTest extends CopilotTagTest
 {
-    public static function expectedWrites()
+    public static function expectedRenders()
     {
         return [
             "expect empty string" => [

--- a/tests/LinkTest.php
+++ b/tests/LinkTest.php
@@ -6,9 +6,9 @@ use CopilotTags\EmbedSubtype;
 
 class LinkTest extends CopilotTagTest
 {
-    public static function expectedWrites()
+    public static function expectedRenders()
     {
-        $embedMarkdown = (new Embed("/photos/123ID", EmbedSubtype::IMAGE, "some caption"))->write();
+        $embedMarkdown = (new Embed("/photos/123ID", EmbedSubtype::IMAGE, "some caption"))->render();
 
         return [
             "expect empty string with no arguments" => [

--- a/tests/ListTagTest.php
+++ b/tests/ListTagTest.php
@@ -5,7 +5,7 @@ use CopilotTags\ListItem;
 
 class ListTagTest extends CopilotTagTest
 {
-    public static function expectedWrites()
+    public static function expectedRenders()
     {
         return [
             "expect unordered list with single item" => [

--- a/tests/ParagraphTest.php
+++ b/tests/ParagraphTest.php
@@ -4,7 +4,7 @@ use CopilotTags\Paragraph;
 
 class ParagraphTest extends CopilotTagTest
 {
-    public static function expectedWrites()
+    public static function expectedRenders()
     {
         return [
             "expect plain text" => [

--- a/tests/SectionTest.php
+++ b/tests/SectionTest.php
@@ -4,7 +4,7 @@ use CopilotTags\Section;
 
 class SectionTest extends CopilotTagTest
 {
-    public static function expectedWrites()
+    public static function expectedRenders()
     {
         return [
             "expect section" => [

--- a/tests/TextTest.php
+++ b/tests/TextTest.php
@@ -4,7 +4,7 @@ use CopilotTags\Text;
 
 class TextTest extends CopilotTagTest
 {
-    public static function expectedWrites()
+    public static function expectedRenders()
     {
         return [
             "expect plain text" => [

--- a/tests/ThematicBreakTest.php
+++ b/tests/ThematicBreakTest.php
@@ -4,7 +4,7 @@ use CopilotTags\ThematicBreak;
 
 class ThematicBreakTest extends CopilotTagTest
 {
-    public static function expectedWrites()
+    public static function expectedRenders()
     {
         return [
             "expect thematic break" => [

--- a/tests/ThematicBreakTest.php
+++ b/tests/ThematicBreakTest.php
@@ -1,14 +1,14 @@
 <?php
 namespace CopilotTags\Tests;
-use CopilotTags\HR;
+use CopilotTags\ThematicBreak;
 
-class HRTest extends CopilotTagTest
+class ThematicBreakTest extends CopilotTagTest
 {
     public static function expectedWrites()
     {
         return [
-            "expect HR" => [
-                new HR(),
+            "expect thematic break" => [
+                new ThematicBreak(),
                 "\n----------\n"
             ]
         ];


### PR DESCRIPTION
Closes: https://app.clubhouse.io/condenastinternational/story/7592

Changes:
* Rename `CopilotTag->write()` to `CopilotTag->render()`.
* Rename `HR` to `ThematicBreak`.
* Add clarification to readme that `ThematicBreak` is also known as horizontal rule or HR.