### PR TITLE
fix example.php undefined offset

### DIFF
--- a/example/example.php
+++ b/example/example.php
@@ -20,7 +20,7 @@ log_var($xml_body, "\$xml_body", "", 1, FALSE);
 
 log_message("Parsing XML...", 1);
 $xml_tag_stack = [];
-$markdown_stack = [];
+$markdown_stack = [""];
 $parser = xml_parser_create();
 xml_set_default_handler($parser, 'add_text');
 xml_set_element_handler($parser, 'on_open_tag', 'on_close_tag');
@@ -66,11 +66,13 @@ function on_open_tag($parser, $name, $attrs) {
 
     log_message("Open tag \"$tagname\". Putting tag on stack...", 2);
     log_var($xml_tag_stack, "\$xml_tag_stack", "BEFORE", 2);
+    log_var($markdown_stack, "\$markdown_stack", "BEFORE", 2);
 
     $xml_tag_stack[] = $tagname;
     $markdown_stack[] = "";
 
     log_var($xml_tag_stack, "\$xml_tag_stack", "AFTER", 2);
+    log_var($markdown_stack, "\$markdown_stack", "AFTER", 2);
 }
 
 function on_close_tag($parser, $name) {


### PR DESCRIPTION
Fixes: https://app.clubhouse.io/condenastinternational/story/7749

PHP notice was occurring in [example.php:123](https://github.com/conde-nast-international/copilot-markdown-generator-php/blob/99c36a8a1de56cff7bec94fa118382d794484b7f/example/example.php#L123) because during the last `on_close_tag` there were no more items in the array. The solution is to initialise the array with an empty string `""` so that the final/top-level/full body render is popped into this item.