### PR TITLE
fix expectedConstructException

### DIFF
--- a/tests/CopilotTagTest.php
+++ b/tests/CopilotTagTest.php
@@ -4,6 +4,10 @@ use PHPUnit\Framework\TestCase;
 
 abstract class CopilotTagTest extends TestCase
 {
+    private static $EXCEPTION_MESSAGE_PATTERN = array(
+        '\InvalidArgumentException' => '/::__construct.+argument \$.+Given:/'
+    );
+
     /**
      * @dataProvider expectedRenders
      */
@@ -15,10 +19,14 @@ abstract class CopilotTagTest extends TestCase
     /**
      * @dataProvider expectedConstructExceptions
      */
-    public function testConstructException($class = NULL, $args = array(), $exception = '\Exception')
+    public function testConstructException($class = NULL, $args = array(), $exceptionType = '\Exception')
     {
         if (!isset($class)) return;
-        $this->setExpectedExceptionRegExp($exception, '/::__construct.+argument \$.+Given:/');
+        if (array_key_exists($exceptionType, self::$EXCEPTION_MESSAGE_PATTERN)) {
+            $this->setExpectedExceptionRegExp($exceptionType, self::$EXCEPTION_MESSAGE_PATTERN[$exceptionType]);
+        } else {
+            $this->setExpectedException($exceptionType);
+        }
         $new = new \ReflectionClass($class);
         $instance = $new->newInstanceArgs($args);
     }


### PR DESCRIPTION
Fixes: https://app.clubhouse.io/condenastinternational/story/8044

Changes:
* Allow `testConstructException` to be used for `Exception` types other than
`InvalidArgumentException`.
* Remove broken/redundant `expectedRenders` method.