### PR TITLE
fix example list converter

### DIFF
--- a/example/example.php
+++ b/example/example.php
@@ -134,6 +134,9 @@ function on_close_tag($parser, $name)
         case 'UL':
             $tag = new CopilotTags\ListTag(string_to_array($text, "\n"), false);
             break;
+        case 'LI':
+            $tag = new CopilotTags\Text("$text\n");
+            break;
         default:
             $tag = new CopilotTags\Text($text);
     }


### PR DESCRIPTION
Fixes: https://app.clubhouse.io/condenastinternational/story/8082

This fixes the example list converter to work properly with the inlining of the XML in this other PR:
https://github.com/conde-nast-international/copilot-markdown-generator-php/pull/29/files#diff-53f96077553334efa218fd0ece78e1d5