### PR TITLE
mark the regexp as Unicode to fix multi-byte chars issue

### DIFF
--- a/src/Text.php
+++ b/src/Text.php
@@ -9,7 +9,8 @@ class Text extends CopilotTag
     {
         if (!is_string($text)) throw new \InvalidArgumentException(__METHOD__." first argument \$text must be a string. Given: ".($text ? "$text " : "")."(".gettype($text).").");
         // convert newline types to LF newlines
-        $text = preg_replace('/\R/', "\n", $text);
+        // mark the regexp as Unicode
+        $text = preg_replace('/\R/u', "\n", $text);
         $this->text = $text;
     }
 


### PR DESCRIPTION
To fix the issue that some Chinese characters are garbled when converted by the markdown generator library.