### PR TITLE
Add space in embed tag between subtype and URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 tmp/
 .DS_Store
+/.idea/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,15 +6,13 @@
 
 You will need to have installed on your machine:
 
-* PHP 5.4. If you're using macOS, it's easiest to install this with [Homebrew]:
+* PHP 5.6. If you're using macOS, it's easiest to install this with [Homebrew]:
   ```shell
-  $ brew tap homebrew/homebrew-php
-  $ brew install homebrew/php/php54
+  $ brew install php@5.6
   ```
 * Composer. [Download Composer][Composer] or install it with [Homebrew]:
   ```shell
-  $ brew tap homebrew/homebrew-php
-  $ brew install homebrew/php/composer
+  $ brew install composer
   ```
 
 There are useful links in the [see also][CONTRIBUTING see also]

--- a/src/Embed.php
+++ b/src/Embed.php
@@ -30,7 +30,7 @@ class Embed extends CopilotTag
     {
         if ($this->uri == "") return "";
         $caption = $this->caption != "" ? "|||$this->caption|||" : "";
-        return "\n\n[#$this->subtype:$this->uri]$caption\n\n";
+        return "\n\n[#$this->subtype: $this->uri]$caption\n\n";
     }
 
     private static function convertHttpToHttps($url)

--- a/tests/CompoundTagTest.php
+++ b/tests/CompoundTagTest.php
@@ -65,59 +65,59 @@ class CompoundTagTest extends CopilotTagTest
             ),
             "expect heading containing only embed" => array(
                 new Heading("$embed"),
-                "\n\n[#image:/photos/123ID]|||some caption|||\n\n"
+                "\n\n[#image: /photos/123ID]|||some caption|||\n\n"
             ),
             "expect heading containing embed with text after" => array(
                 new Heading("$embed Hello world!"),
-                "\n\n[#image:/photos/123ID]|||some caption|||\n\n## Hello world!\n"
+                "\n\n[#image: /photos/123ID]|||some caption|||\n\n## Hello world!\n"
             ),
             "expect heading containing embed with text before" => array(
                 new Heading("Hello world! $embed"),
-                "\n\n## Hello world! \n\n[#image:/photos/123ID]|||some caption|||\n\n"
+                "\n\n## Hello world! \n\n[#image: /photos/123ID]|||some caption|||\n\n"
             ),
             "expect heading containing embed with text before and after" => array(
                 new Heading("Hello world! $embed It's me again"),
-                "\n\n## Hello world! \n\n[#image:/photos/123ID]|||some caption|||\n\n## It's me again\n"
+                "\n\n## Hello world! \n\n[#image: /photos/123ID]|||some caption|||\n\n## It's me again\n"
             ),
             "expect inline text conatining only embed" => array(
                 new InlineText("$embed", ":"),
-                "\n\n[#image:/photos/123ID]|||some caption|||\n\n"
+                "\n\n[#image: /photos/123ID]|||some caption|||\n\n"
             ),
             "expect inline text conatining embed with text after" => array(
                 new InlineText("$embed Hello world!", ":"),
-                "\n\n[#image:/photos/123ID]|||some caption|||\n\n :Hello world!:"
+                "\n\n[#image: /photos/123ID]|||some caption|||\n\n :Hello world!:"
             ),
             "expect inline text conatining embed with text before" => array(
                 new InlineText("Hello world! $embed", ":"),
-                ":Hello world!: \n\n[#image:/photos/123ID]|||some caption|||\n\n"
+                ":Hello world!: \n\n[#image: /photos/123ID]|||some caption|||\n\n"
             ),
             "expect inline text conatining embed with text before and after" => array(
                 new InlineText("Hello world! $embed It's me again", ":"),
-                ":Hello world!: \n\n[#image:/photos/123ID]|||some caption|||\n\n :It's me again:"
+                ":Hello world!: \n\n[#image: /photos/123ID]|||some caption|||\n\n :It's me again:"
             ),
             "expect link containing only embed" => array(
                 new Link("$embed", "http://li.nk"),
-                "\n\n[#image:/photos/123ID]|||some caption|||\n\n"
+                "\n\n[#image: /photos/123ID]|||some caption|||\n\n"
             ),
             "expect link containing only multiple embeds" => array(
                 new Link("{$embed}{$embed}", "http://li.nk"),
-                "\n\n[#image:/photos/123ID]|||some caption|||\n\n[#image:/photos/123ID]|||some caption|||\n\n"
+                "\n\n[#image: /photos/123ID]|||some caption|||\n\n[#image: /photos/123ID]|||some caption|||\n\n"
             ),
             "expect link containing text with embed at start and end" => array(
                 new Link("{$embed}some text yo{$embed}", "http://li.nk"),
-                "\n\n[#image:/photos/123ID]|||some caption|||\n\n[some text yo](http://li.nk)\n\n[#image:/photos/123ID]|||some caption|||\n\n"
+                "\n\n[#image: /photos/123ID]|||some caption|||\n\n[some text yo](http://li.nk)\n\n[#image: /photos/123ID]|||some caption|||\n\n"
             ),
             "expect link containing text with embed at end" => array(
                 new Link("some text yo $embed", "http://li.nk"),
-                "[some text yo](http://li.nk) \n\n[#image:/photos/123ID]|||some caption|||\n\n"
+                "[some text yo](http://li.nk) \n\n[#image: /photos/123ID]|||some caption|||\n\n"
             ),
             "expect link containing text with embed at start" => array(
                 new Link("$embed some text yo", "http://li.nk"),
-                "\n\n[#image:/photos/123ID]|||some caption|||\n\n [some text yo](http://li.nk)"
+                "\n\n[#image: /photos/123ID]|||some caption|||\n\n [some text yo](http://li.nk)"
             ),
             "expect link containing text with embed" => array(
                 new Link("this is $embed some text yo", "http://li.nk"),
-                "[this is](http://li.nk) \n\n[#image:/photos/123ID]|||some caption|||\n\n [some text yo](http://li.nk)"
+                "[this is](http://li.nk) \n\n[#image: /photos/123ID]|||some caption|||\n\n [some text yo](http://li.nk)"
             )
         );
     }

--- a/tests/EmbedTest.php
+++ b/tests/EmbedTest.php
@@ -10,15 +10,15 @@ class EmbedTest extends CopilotTagTest
         return array(
             "expect embed with subtype" => array(
                 new Embed("https://www.google.com", EmbedSubtype::VIDEO),
-                "\n\n[#video:https://www.google.com]\n\n"
+                "\n\n[#video: https://www.google.com]\n\n"
             ),
             "expect embed with default subtype" => array(
                 new Embed("https://www.google.com"),
-                "\n\n[#iframe:https://www.google.com]\n\n"
+                "\n\n[#iframe: https://www.google.com]\n\n"
             ),
             "expect embed with http uri converted to https" => array(
                 new Embed("http://www.google.com"),
-                "\n\n[#iframe:https://www.google.com]\n\n"
+                "\n\n[#iframe: https://www.google.com]\n\n"
             ),
             "expect empty string" => array(
                 new Embed(""),
@@ -26,35 +26,35 @@ class EmbedTest extends CopilotTagTest
             ),
             "expect embed with caption" => array(
                 new Embed("https://www.google.com", EmbedSubtype::IFRAME, "some caption"),
-                "\n\n[#iframe:https://www.google.com]|||some caption|||\n\n"
+                "\n\n[#iframe: https://www.google.com]|||some caption|||\n\n"
             ),
             "expect image embed with caption and uri beginning with forward slash" => array(
                 new Embed("/photos/123ID", EmbedSubtype::IMAGE, "some caption"),
-                "\n\n[#image:/photos/123ID]|||some caption|||\n\n"
+                "\n\n[#image: /photos/123ID]|||some caption|||\n\n"
             ),
             "expect embed with leading whitespace in uri trimmed" => array(
                 new Embed(" https://www.google.com"),
-                "\n\n[#iframe:https://www.google.com]\n\n"
+                "\n\n[#iframe: https://www.google.com]\n\n"
             ),
             "expect embed with trailing whitespace in uri trimmed" => array(
                 new Embed("https://www.google.com "),
-                "\n\n[#iframe:https://www.google.com]\n\n"
+                "\n\n[#iframe: https://www.google.com]\n\n"
             ),
             "expect embed with leading and trailing whitespace in uri trimmed" => array(
                 new Embed(" https://www.google.com "),
-                "\n\n[#iframe:https://www.google.com]\n\n"
+                "\n\n[#iframe: https://www.google.com]\n\n"
             ),
             "expect embed with trailing newline in uri trimmed" => array(
                 new Embed("https://www.google.com\n"),
-                "\n\n[#iframe:https://www.google.com]\n\n"
+                "\n\n[#iframe: https://www.google.com]\n\n"
             ),
             "expect embed with leading newline in uri trimmed" => array(
                 new Embed("\nhttps://www.google.com"),
-                "\n\n[#iframe:https://www.google.com]\n\n"
+                "\n\n[#iframe: https://www.google.com]\n\n"
             ),
             "expect embed with leading and trailing newlines in uri trimmed" => array(
                 new Embed("\nhttps://www.google.com\n"),
-                "\n\n[#iframe:https://www.google.com]\n\n"
+                "\n\n[#iframe: https://www.google.com]\n\n"
             ),
             "expect empty string for only whitespace in uri" => array(
                 new Embed("  "),


### PR DESCRIPTION
This avoids [Copilot editor breaks if no space between embed subtype and URL](https://app.clubhouse.io/condenastinternational/story/20514/copilot-editor-breaks-if-no-space-between-embed-subtype-and-url).

- [x] tests added